### PR TITLE
Feat: Adding Strict Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,20 @@
   TapBlok makes you earn your screen time back. Start a focus session and your chosen apps are locked — the only way out is scanning an NFC tag or QR code you've placed somewhere inconvenient. No digital bypass. No "just this once."
 </p>
 
-<p align="center">
-  <a href="https://github.com/cajdata/TapBlok/releases/latest">
-    <img src="https://img.shields.io/github/v/release/cajdata/TapBlok?label=Download&logo=android&color=00C27A" />
-  </a>
-</p>
 
 <p align="center">Android 7.0+ &nbsp;·&nbsp; Apache 2.0 &nbsp;·&nbsp; Free, no subscription</p>
+
+---
+
+## 🛠️ Fork Updates
+
+The exit logic has been overhauled to provide dynamic resistance based on your focus goals:
+
+- **Mode-Aware Exits**: 
+    - **Chill Mode**: (Same as original app) Any valid NFC/QR scan toggles monitoring immediately, even from the block screen.
+    - **Strict Mode**: Scanning on a block screen grants a **temporary timed unlock for the single app**. Stopping requires scanning while TapBlok is in the foreground.
+- **Improved Feedback**: A silent notification will appear to tell you how much time you have left if you are in strict mode.
+- **Unified Payloads**: Both `TAPBLOK_TOGGLE` and `TAPBLOK_UNLOCK:<duration>` are now supported.
 
 ---
 
@@ -47,18 +54,33 @@
 - **🔒 Block Any App** — Choose any launchable app on your device. Critical system apps (dialer, settings, launcher) are permanently excluded so you can't lock yourself out.
 - **☕ Smart Breaks** — Take up to 3 five-minute breaks per session without ending it.
 - **🔁 Boot Persistence** — If your device restarts mid-session, TapBlok picks right back up.
-- **🚨 Emergency Override** — Lost your tag? A 90-second hold gives you a last resort exit — slow enough to stop impulse bypassing.
+- **🚨 Emergency Override** — Lost your tag? A 90-s[README.md](README.md)econd hold gives you a last resort exit — slow enough to stop impulse bypassing.
 - **📊 Attempt Counter** — See how many times you tried to open a blocked app. Accountability you can't ignore.
 - **⚡ App Shortcut** — Long-press the TapBlok icon to start a session instantly.
-- **🔓 Open Source** — Every line of code is on GitHub. No black boxes, ever.
 - **🆓 Completely Free** — No subscription, no in-app purchases, no tracking, no cloud.
 
 ---
 
-## 🚀 Getting Started
+## 🛡️ Modes of Operation
 
-1. **Install** — Download the APK from the [latest release](https://github.com/cajdata/TapBlok/releases/latest) and install it.
-2. **Grant permissions** — Usage Access and Display Over Other Apps are required. TapBlok will prompt you.
+TapBlok now offers two modes to match your focus needs:
+
+### Chill Mode (Default)
+Any valid scan (NFC or QR) immediately toggles the monitoring state. If you're on a block screen, scanning your tag will end the session instantly. Best for those who want a simple physical switch for their focus.
+
+### Strict Mode
+Designed for maximum friction and discipline:
+- **Foreground Enforcement**: Monitoring can only be stopped by scanning your tag while the TapBlok app is open in the foreground. Background scans will trigger a "Strict Mode Active" notification.
+- **Timed Unlocks**: Scanning a tag from a block screen won't end the session; instead, it grants a temporary unlock (default 5 minutes) for that specific app.
+- **Dynamic Feedback**: The persistent notification only shows active unlock timers and hides itself when idle to reduce clutter.
+
+---
+
+## 🚀 Getting Started
+**Note on Installation**: The APKs on my fork will not be signed. You will get a scary popup saying "Unrecognised developer"! If you don't trust this, you will have to build the app from source.
+
+1. **Install** — Download the APK from the [latest release](https://github.com/cajdata/TapBlok/releases/latest) and install it (you will likely need to click something like "more details > install anyway".
+2. **Grant permissions** — Usage Access and Display Over Other Apps are required, notifications are suggested. TapBlok will prompt you. 
 3. **Pick your apps** — Tap "Manage Blocked Apps" and select the apps you want to block.
 4. **Set up your unlock method** — Write an NFC tag in-app, or generate a QR code and print it.
 5. **Start a session** — Tap "Start Monitoring" and put the tag somewhere out of arm's reach.
@@ -119,3 +141,4 @@ Apache 2.0 — see [LICENSE](LICENSE) for details.
 <p align="center">
   Made in Denver, CO 🏔️
 </p>
+

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Designed for maximum friction and discipline:
 ## 🚀 Getting Started
 **Note on Installation**: The APKs on my fork will not be signed. You will get a scary popup saying "Unrecognised developer"! If you don't trust this, you will have to build the app from source.
 
-1. **Install** — Download the APK from the [latest release](https://github.com/cajdata/TapBlok/releases/latest) and install it (you will likely need to click something like "more details > install anyway".
+1. **Install** — Download the APK from the [latest release](https://github.com/ImLouisxyz/TapBlok/releases/latest) and install it (you will likely need to click something like "more details > install anyway".
 2. **Grant permissions** — Usage Access and Display Over Other Apps are required, notifications are suggested. TapBlok will prompt you. 
 3. **Pick your apps** — Tap "Manage Blocked Apps" and select the apps you want to block.
 4. **Set up your unlock method** — Write an NFC tag in-app, or generate a QR code and print it.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,15 +1,8 @@
-import java.util.Properties
-
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
-}
-
-val localProps = Properties().apply {
-    val f = rootProject.file("local.properties")
-    if (f.exists()) load(f.inputStream())
 }
 
 android {
@@ -20,24 +13,14 @@ android {
         applicationId = "com.cj.tapblok"
         minSdk = 24
         targetSdk = 36
-        versionCode = 4
-        versionName = "1.2.1"
+        versionCode = 5
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
-    signingConfigs {
-        create("release") {
-            storeFile = file(localProps.getProperty("RELEASE_STORE_FILE", ""))
-            storePassword = localProps.getProperty("RELEASE_STORE_PASSWORD", "")
-            keyAlias = localProps.getProperty("RELEASE_KEY_ALIAS", "")
-            keyPassword = localProps.getProperty("RELEASE_KEY_PASSWORD", "")
-        }
-    }
-
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
@@ -86,4 +69,3 @@ dependencies {
     implementation(libs.zxing.core)
     implementation(libs.zxing.android.embedded)
 }
-

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,12 +13,16 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
-    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.CAMERA"  />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
     <uses-permission android:name="android.permission.NFC" />
 
     <uses-feature
         android:name="android.hardware.nfc"
+        android:required="false" />
+    <uses-feature
+        android:name="android.hardware.camera"
         android:required="false" />
 
     <application

--- a/app/src/main/java/com/cj/tapblok/App.kt
+++ b/app/src/main/java/com/cj/tapblok/App.kt
@@ -19,16 +19,28 @@ class App : Application() {
         // Create the NotificationChannel, but only on API 26+ because
         // the NotificationChannel class is new and not in the support library
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            val name = "App Monitoring"
-            val descriptionText = "Channel for the app monitoring service"
-            val importance = NotificationManager.IMPORTANCE_DEFAULT
-            val channel = NotificationChannel(AppMonitoringService.CHANNEL_ID, name, importance).apply {
-                description = descriptionText
-            }
-            // Register the channel with the system
             val notificationManager: NotificationManager =
                 getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-            notificationManager.createNotificationChannel(channel)
+
+            // Monitoring channel (silent)
+            val monitoringChannel = NotificationChannel(
+                AppMonitoringService.CHANNEL_ID,
+                "App Monitoring",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Channel for the app monitoring service"
+            }
+            notificationManager.createNotificationChannel(monitoringChannel)
+
+            // Alerts channel (high priority)
+            val alertChannel = NotificationChannel(
+                "tapblok_alerts",
+                "Alerts",
+                NotificationManager.IMPORTANCE_HIGH
+            ).apply {
+                description = "Channel for important TapBlok alerts"
+            }
+            notificationManager.createNotificationChannel(alertChannel)
         }
     }
 }

--- a/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
+++ b/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
@@ -1,10 +1,13 @@
 package com.cj.tapblok
 
+import android.app.NotificationManager
 import android.app.PendingIntent
 import android.app.Service
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.CountDownTimer
 import android.os.IBinder
 import android.provider.Settings
@@ -18,6 +21,10 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.concurrent.ConcurrentHashMap
 
 class AppMonitoringService : Service() {
 
@@ -26,14 +33,30 @@ class AppMonitoringService : Service() {
     private lateinit var prefs: android.content.SharedPreferences
     @Volatile private var blockedApps: Set<String> = emptySet()
     @Volatile private var isBreakActive = false
+    
+    // Package Name -> Expiry Timestamp (millis)
+    private val temporarilyUnlockedApps = ConcurrentHashMap<String, Long>()
+    private val appLabelCache = ConcurrentHashMap<String, String>()
+    private var lastNotificationText: String? = null
+    
     private var isMonitoring = false
     private var breakTimer: CountDownTimer? = null
+    private val notificationManager by lazy { getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager }
 
     companion object {
         const val NOTIFICATION_ID = 1
         const val CHANNEL_ID = "app_monitoring_channel"
         const val ACTION_START_BREAK = "com.cj.tapblok.ACTION_START_BREAK"
-        @Volatile var isRunning = false
+        const val ACTION_UNLOCK_APP = "com.cj.tapblok.ACTION_UNLOCK_APP"
+        const val EXTRA_PACKAGE_NAME = "extra_package_name"
+        const val EXTRA_DURATION_MINUTES = "extra_duration_minutes"
+        
+        private val _isRunning = MutableStateFlow(false)
+        val isRunningFlow: StateFlow<Boolean> = _isRunning.asStateFlow()
+        
+        var isRunning: Boolean
+            get() = _isRunning.value
+            set(value) { _isRunning.value = value }
     }
 
     override fun onCreate() {
@@ -41,12 +64,26 @@ class AppMonitoringService : Service() {
         db = AppDatabase.getDatabase(this)
         prefs = getSharedPreferences("app_prefs", MODE_PRIVATE)
         isRunning = true
+        Log.d("AppMonitoringService", "Service onCreate")
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        if (intent?.action == ACTION_START_BREAK) {
-            startBreak()
-            return START_NOT_STICKY
+        when (intent?.action) {
+            ACTION_START_BREAK -> {
+                startBreak()
+                return START_NOT_STICKY
+            }
+            ACTION_UNLOCK_APP -> {
+                val pkg = intent.getStringExtra(EXTRA_PACKAGE_NAME)
+                val duration = intent.getIntExtra(EXTRA_DURATION_MINUTES, 0)
+                if (pkg != null && duration > 0) {
+                    temporarilyUnlockedApps[pkg] = System.currentTimeMillis() + (duration * 60 * 1000L)
+                    Log.d("AppMonitoringService", "Unlocked $pkg for $duration minutes")
+                    // Trigger immediate update
+                    updateNotificationFromMap()
+                }
+                return START_STICKY
+            }
         }
 
         Log.d("AppMonitoringService", "Service has started.")
@@ -58,22 +95,11 @@ class AppMonitoringService : Service() {
         }
 
         val notificationIntent = Intent(this, MainActivity::class.java)
-        val pendingIntent = PendingIntent.getActivity(
-            this,
-            0,
-            notificationIntent,
-            PendingIntent.FLAG_IMMUTABLE
-        )
+        // pendingIntent is used inside createNotification()
 
-        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setContentTitle("TapBlok is Active")
-            .setContentText("App monitoring and blocking is running.")
-            .setSmallIcon(R.mipmap.ic_launcher)
-            .setContentIntent(pendingIntent)
-            .setOngoing(true)
-            .build()
-
-        startForeground(NOTIFICATION_ID, notification)
+        // Always start as foreground to ensure reliability, but we'll hide it if no unlocks exist
+        startForeground(NOTIFICATION_ID, createNotification())
+        updateNotificationFromMap()
 
         if (isMonitoring) return START_STICKY
         isMonitoring = true
@@ -95,11 +121,17 @@ class AppMonitoringService : Service() {
                     break
                 }
 
+                updateNotificationFromMap()
+
                 if (!isBreakActive) {
                     val foregroundApp = getForegroundApp()
-                    if (BuildConfig.DEBUG) Log.d("AppMonitoringService", "Current App: $foregroundApp")
+                    
+                    val isTempUnlocked = foregroundApp?.let {
+                        val expiry = temporarilyUnlockedApps[it]
+                        expiry != null && expiry > System.currentTimeMillis()
+                    } ?: false
 
-                    if (foregroundApp != null && foregroundApp in blockedApps && foregroundApp != packageName) {
+                    if (foregroundApp != null && foregroundApp in blockedApps && foregroundApp != packageName && !isTempUnlocked) {
                         val blockIntent = Intent(localContext, BlockingActivity::class.java).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             putExtra("BLOCKED_APP_PACKAGE_NAME", foregroundApp)
@@ -149,6 +181,91 @@ class AppMonitoringService : Service() {
         return null
     }
 
+    private fun createNotification(contentText: String? = null): android.app.Notification {
+        val notificationIntent = Intent(this, MainActivity::class.java)
+        val pendingIntent = PendingIntent.getActivity(
+            this,
+            0,
+            notificationIntent,
+            PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val builder = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("TapBlok is Active")
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentIntent(pendingIntent)
+            .setOngoing(true)
+            .setSilent(true)
+
+        if (contentText != null) {
+            builder.setContentText(contentText)
+        }
+
+        return builder.build()
+    }
+
+    private fun updateNotificationFromMap() {
+        val now = System.currentTimeMillis()
+        val activeUnlocks = mutableListOf<String>()
+        
+        val iterator = temporarilyUnlockedApps.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if (entry.value <= now) {
+                iterator.remove()
+            } else {
+                val remainingMinutes = ((entry.value - now) / 60000L) + 1
+                val appLabel = getAppLabel(entry.key)
+                activeUnlocks.add("$appLabel: ${remainingMinutes}m")
+            }
+        }
+        updateNotification(activeUnlocks)
+    }
+
+    private fun updateNotification(activeUnlocks: List<String>) {
+        val contentText = if (activeUnlocks.isEmpty()) {
+            null
+        } else {
+            "Unlocked: ${activeUnlocks.joinToString(", ")}"
+        }
+        
+        if (contentText == lastNotificationText) return
+        lastNotificationText = contentText
+        
+        if (contentText == null) {
+            // No active unlocks, remove foreground notification.
+            // Note: The service remains running in the background.
+            stopForeground(STOP_FOREGROUND_REMOVE)
+        } else {
+            val notification = createNotification(contentText)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                if (checkSelfPermission(android.Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED) {
+                    startForeground(NOTIFICATION_ID, notification)
+                }
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        }
+    }
+
+    private fun getAppLabel(packageName: String): String {
+        appLabelCache[packageName]?.let { return it }
+        val label = try {
+            val pm = packageManager
+            val appInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                pm.getApplicationInfo(packageName, PackageManager.ApplicationInfoFlags.of(0))
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getApplicationInfo(packageName, 0)
+            }
+            pm.getApplicationLabel(appInfo).toString()
+        } catch (e: Exception) {
+            packageName
+        }
+        appLabelCache[packageName] = label
+        return label
+    }
+
     private fun getForegroundApp(): String? {
         val usageStatsManager = getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
         val time = System.currentTimeMillis()
@@ -160,4 +277,3 @@ class AppMonitoringService : Service() {
         return appList?.maxByOrNull { it.lastTimeUsed }?.packageName
     }
 }
-

--- a/app/src/main/java/com/cj/tapblok/BlockingActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/BlockingActivity.kt
@@ -1,13 +1,18 @@
 package com.cj.tapblok
 
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
+import android.nfc.NdefMessage
+import android.nfc.NfcAdapter
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -17,12 +22,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Lock
-import androidx.compose.material3.Button
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.filled.QrCodeScanner
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
@@ -35,12 +36,19 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.edit
 import coil.compose.rememberAsyncImagePainter
 import com.cj.tapblok.ui.theme.TapBlokTheme
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 
 class BlockingActivity : ComponentActivity() {
+    private var nfcAdapter: NfcAdapter? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         val packageName = intent.getStringExtra("BLOCKED_APP_PACKAGE_NAME") ?: "An app"
+        val prefs = getSharedPreferences("app_prefs", MODE_PRIVATE)
+        val isStrictMode = prefs.getBoolean("is_strict_mode", false)
 
         val goHome = {
             val intent = Intent(Intent.ACTION_MAIN).apply {
@@ -59,6 +67,7 @@ class BlockingActivity : ComponentActivity() {
             TapBlokTheme {
                 BlockingScreen(
                     packageName = packageName,
+                    isStrictMode = isStrictMode,
                     onGoHomeClick = goHome,
                     onTakeBreakClick = {
                         val breakIntent = Intent(this, AppMonitoringService::class.java).apply {
@@ -66,8 +75,65 @@ class BlockingActivity : ComponentActivity() {
                         }
                         startService(breakIntent)
                         finish()
-                    }
+                    },
+                    onAppUnlocked = { finish() }
                 )
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
+        nfcAdapter?.enableForegroundDispatch(this, pendingIntent, null, null)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        nfcAdapter?.disableForegroundDispatch(this)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        if (NfcAdapter.ACTION_NDEF_DISCOVERED == intent.action) {
+            val messages = intent.getParcelableArrayExtraCompat<NdefMessage>(NfcAdapter.EXTRA_NDEF_MESSAGES)
+            if (!messages.isNullOrEmpty()) {
+                val ndefMessage = messages[0] as NdefMessage
+                val record = ndefMessage.records[0]
+                val payload = String(record.payload, Charsets.UTF_8)
+                val packageName = this.intent.getStringExtra("BLOCKED_APP_PACKAGE_NAME")
+
+                if (packageName != null) {
+                    val prefs = getSharedPreferences("app_prefs", MODE_PRIVATE)
+                    val isStrictMode = prefs.getBoolean("is_strict_mode", false)
+
+                    if (!isStrictMode) {
+                        // Chill Mode: Scanning any valid tag (Toggle or Unlock) on block screen stops monitoring
+                        if (payload == "TAPBLOK_TOGGLE" || payload.startsWith("TAPBLOK_UNLOCK:")) {
+                            stopService(Intent(this, AppMonitoringService::class.java))
+                            Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+                            finish()
+                            return
+                        }
+                    } else {
+                        // Strict Mode: Pause monitoring (unlock) for specific durations
+                        var duration = prefs.getInt("default_unlock_duration", 5)
+                        if (payload.startsWith("TAPBLOK_UNLOCK:")) {
+                            duration = payload.removePrefix("TAPBLOK_UNLOCK:").toIntOrNull() ?: duration
+                        } else if (payload != "TAPBLOK_TOGGLE") {
+                            return
+                        }
+
+                        val unlockIntent = Intent(this, AppMonitoringService::class.java).apply {
+                            action = AppMonitoringService.ACTION_UNLOCK_APP
+                            putExtra(AppMonitoringService.EXTRA_PACKAGE_NAME, packageName)
+                            putExtra(AppMonitoringService.EXTRA_DURATION_MINUTES, duration)
+                        }
+                        startService(unlockIntent)
+                        finish()
+                    }
+                }
             }
         }
     }
@@ -76,17 +142,54 @@ class BlockingActivity : ComponentActivity() {
 @Composable
 fun BlockingScreen(
     packageName: String,
+    isStrictMode: Boolean,
     onGoHomeClick: () -> Unit,
-    onTakeBreakClick: () -> Unit
+    onTakeBreakClick: () -> Unit,
+    onAppUnlocked: () -> Unit
 ) {
     val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE) }
 
     var appName by remember { mutableStateOf(packageName) }
     var appIcon by remember { mutableStateOf<Drawable?>(null) }
-    var breaksRemaining by rememberSaveable { mutableStateOf(0) }
+    var breaksRemaining by rememberSaveable { mutableIntStateOf(0) }
+
+    val qrCodeScannerLauncher = rememberLauncherForActivityResult(
+        contract = ScanContract()
+    ) { result ->
+        if (result.contents != null) {
+            val content = result.contents
+            
+            if (!isStrictMode) {
+                // Chill Mode: Scanning any valid tag on block screen stops monitoring
+                if (content == QrCodeActivity.QR_CODE_CONTENT || content.startsWith("TAPBLOK_UNLOCK:")) {
+                    context.stopService(Intent(context, AppMonitoringService::class.java))
+                    Toast.makeText(context, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+                    onAppUnlocked()
+                    return@rememberLauncherForActivityResult
+                }
+            } else {
+                // Strict Mode: Unlocks
+                var duration = prefs.getInt("default_unlock_duration", 5)
+                if (content.startsWith("TAPBLOK_UNLOCK:")) {
+                    duration = content.removePrefix("TAPBLOK_UNLOCK:").toIntOrNull() ?: duration
+                } else if (content != QrCodeActivity.QR_CODE_CONTENT) {
+                    Toast.makeText(context, "Invalid QR Code", Toast.LENGTH_SHORT).show()
+                    return@rememberLauncherForActivityResult
+                }
+
+                val unlockIntent = Intent(context, AppMonitoringService::class.java).apply {
+                    action = AppMonitoringService.ACTION_UNLOCK_APP
+                    putExtra(AppMonitoringService.EXTRA_PACKAGE_NAME, packageName)
+                    putExtra(AppMonitoringService.EXTRA_DURATION_MINUTES, duration)
+                }
+                context.startService(unlockIntent)
+                onAppUnlocked()
+            }
+        }
+    }
 
     LaunchedEffect(key1 = Unit) {
-        val prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
         breaksRemaining = prefs.getInt("breaks_remaining", 0)
 
         val pm = context.packageManager
@@ -161,7 +264,8 @@ fun BlockingScreen(
             Spacer(modifier = Modifier.height(12.dp))
 
             Text(
-                text = "Tap your NFC tag or scan your QR code to unlock.",
+                text = if (isStrictMode) "Strict mode is active. Scan to unlock this app temporarily."
+                       else "Tap your NFC tag or scan your QR code to unlock.",
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -176,11 +280,24 @@ fun BlockingScreen(
                 Text("Go Home")
             }
 
-            if (breaksRemaining > 0) {
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = {
+                    qrCodeScannerLauncher.launch(ScanOptions().setOrientationLocked(true))
+                },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+            ) {
+                Icon(imageVector = Icons.Default.QrCodeScanner, contentDescription = null)
+                Spacer(modifier = Modifier.width(8.dp))
+                Text("Scan to Unlock")
+            }
+
+            if (!isStrictMode && breaksRemaining > 0) {
                 Spacer(modifier = Modifier.height(12.dp))
                 OutlinedButton(
                     onClick = {
-                        val prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
                         prefs.edit { putInt("breaks_remaining", breaksRemaining - 1) }
                         onTakeBreakClick()
                     },

--- a/app/src/main/java/com/cj/tapblok/MainActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/MainActivity.kt
@@ -1,9 +1,13 @@
 package com.cj.tapblok
 
 import android.Manifest
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.nfc.NdefMessage
+import android.nfc.NfcAdapter
+import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Toast
@@ -19,21 +23,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Apps
-import androidx.compose.material.icons.filled.ChevronRight
-import androidx.compose.material.icons.filled.Nfc
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.QrCode2
-import androidx.compose.material.icons.filled.QrCodeScanner
-import androidx.compose.material.icons.filled.Security
-import androidx.compose.material3.Button
-import androidx.compose.material3.ElevatedCard
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.LinearProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material.icons.filled.*
+import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,24 +33,80 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
+import androidx.core.content.edit
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.cj.tapblok.ui.theme.TapBlokTheme
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
 import kotlinx.coroutines.delay
 
 class MainActivity : ComponentActivity() {
+    private var nfcAdapter: NfcAdapter? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        nfcAdapter = NfcAdapter.getDefaultAdapter(this)
         setContent {
             TapBlokTheme {
                 MainScreen()
+            }
+        }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+        val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
+        nfcAdapter?.enableForegroundDispatch(this, pendingIntent, null, null)
+        
+        // Clear any "Strict Mode Active" warning notifications
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as android.app.NotificationManager
+        notificationManager.cancel(1001)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        nfcAdapter?.disableForegroundDispatch(this)
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val action = intent.action
+        if (action == NfcAdapter.ACTION_NDEF_DISCOVERED ||
+            action == NfcAdapter.ACTION_TECH_DISCOVERED ||
+            action == NfcAdapter.ACTION_TAG_DISCOVERED
+        ) {
+            val messages =
+                intent.getParcelableArrayExtraCompat<NdefMessage>(NfcAdapter.EXTRA_NDEF_MESSAGES)
+            if (!messages.isNullOrEmpty()) {
+                val ndefMessage = messages[0] as NdefMessage
+                if (ndefMessage.records.isNotEmpty()) {
+                    val record = ndefMessage.records[0]
+                    val payload = String(record.payload, Charsets.UTF_8)
+                    handleNfcPayload(payload)
+                }
+            }
+        }
+    }
+
+    private fun handleNfcPayload(payload: String) {
+        val isTogglePayload = payload == "TAPBLOK_TOGGLE"
+        val isUnlockPayload = payload.startsWith("TAPBLOK_UNLOCK:")
+
+        if (isTogglePayload || isUnlockPayload) {
+            if (AppMonitoringService.isRunning) {
+                stopService(Intent(this, AppMonitoringService::class.java))
+                Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+            } else {
+                startMonitoringService(this)
+                Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -69,14 +116,34 @@ class MainActivity : ComponentActivity() {
 fun MainScreen() {
     val context = LocalContext.current
     val lifecycleOwner = LocalLifecycleOwner.current
+    val prefs = remember { context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE) }
 
+    val isServiceRunning by AppMonitoringService.isRunningFlow.collectAsStateWithLifecycle()
     var hasUsagePermission by remember { mutableStateOf(hasUsageStatsPermission(context)) }
     var canDrawOverlays by remember { mutableStateOf(Settings.canDrawOverlays(context)) }
-    var isServiceRunning by remember { mutableStateOf(isServiceRunning(context, AppMonitoringService::class.java)) }
+    
     var blockedAppAttempts by remember { mutableStateOf(0) }
+    
+    var isStrictMode by remember {
+        mutableStateOf(prefs.getBoolean("is_strict_mode", false))
+    }
+    var defaultUnlockDuration by remember {
+        mutableStateOf(prefs.getInt("default_unlock_duration", 5))
+    }
+    
     var hasCameraPermission by remember {
         mutableStateOf(
             ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+    
+    var hasNotificationPermission by remember {
+        mutableStateOf(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) == PackageManager.PERMISSION_GRANTED
+            } else {
+                true
+            }
         )
     }
 
@@ -88,28 +155,35 @@ fun MainScreen() {
     ) {
         hasUsagePermission = hasUsageStatsPermission(context)
         canDrawOverlays = Settings.canDrawOverlays(context)
-        isServiceRunning = isServiceRunning(context, AppMonitoringService::class.java)
     }
 
     val cameraPermissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted -> hasCameraPermission = isGranted }
 
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted -> hasNotificationPermission = isGranted }
+
     val qrCodeScannerLauncher = rememberLauncherForActivityResult(
         contract = ScanContract()
     ) { result ->
-        if (result.contents == QrCodeActivity.QR_CODE_CONTENT) {
-            if (isServiceRunning) {
-                context.stopService(Intent(context, AppMonitoringService::class.java))
-                Toast.makeText(context, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
-                isServiceRunning = false
+        if (result.contents != null) {
+            val content = result.contents
+            val isTogglePayload = content == QrCodeActivity.QR_CODE_CONTENT
+            val isUnlockPayload = content.startsWith("TAPBLOK_UNLOCK:")
+            
+            if (isTogglePayload || isUnlockPayload) {
+                if (isServiceRunning) {
+                    context.stopService(Intent(context, AppMonitoringService::class.java))
+                    Toast.makeText(context, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+                } else {
+                    startMonitoringService(context)
+                    Toast.makeText(context, "Monitoring started.", Toast.LENGTH_SHORT).show()
+                }
             } else {
-                startMonitoringService(context)
-                Toast.makeText(context, "Monitoring started.", Toast.LENGTH_SHORT).show()
-                isServiceRunning = true
+                Toast.makeText(context, "Incorrect QR Code", Toast.LENGTH_SHORT).show()
             }
-        } else if (result.contents != null) {
-            Toast.makeText(context, "Incorrect QR Code", Toast.LENGTH_SHORT).show()
         }
     }
 
@@ -118,12 +192,17 @@ fun MainScreen() {
             if (event == Lifecycle.Event.ON_RESUME) {
                 hasUsagePermission = hasUsageStatsPermission(context)
                 canDrawOverlays = Settings.canDrawOverlays(context)
-                isServiceRunning = isServiceRunning(context, AppMonitoringService::class.java)
-                val prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
                 blockedAppAttempts = prefs.getInt("blocked_app_attempts", 0)
                 hasCameraPermission = ContextCompat.checkSelfPermission(
                     context, Manifest.permission.CAMERA
                 ) == PackageManager.PERMISSION_GRANTED
+                hasNotificationPermission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    ContextCompat.checkSelfPermission(
+                        context, Manifest.permission.POST_NOTIFICATIONS
+                    ) == PackageManager.PERMISSION_GRANTED
+                } else {
+                    true
+                }
             }
         }
         lifecycleOwner.lifecycle.addObserver(observer)
@@ -141,7 +220,6 @@ fun MainScreen() {
             if (isHolding) {
                 holdProgress = 1f
                 context.stopService(Intent(context, AppMonitoringService::class.java))
-                isServiceRunning = false
             }
         } else {
             holdProgress = 0f
@@ -216,26 +294,91 @@ fun MainScreen() {
                     }
                 }
 
-                // Primary action button — only shown when not monitoring
+                // Mode Selection
+                ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column {
+                                Text(
+                                    text = if (isStrictMode) "Strict Mode" else "Chill Mode",
+                                    style = MaterialTheme.typography.titleMedium
+                                )
+                                Text(
+                                    text = if (isStrictMode) "No breaks. NFC/QR scan required." else "Standard mode with breaks.",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                )
+                            }
+                            Switch(
+                                checked = isStrictMode,
+                                onCheckedChange = {
+                                    if (!isServiceRunning) {
+                                        isStrictMode = it
+                                        prefs.edit { putBoolean("is_strict_mode", it) }
+                                    } else {
+                                        Toast.makeText(context, "Cannot change mode while monitoring", Toast.LENGTH_SHORT).show()
+                                    }
+                                },
+                                enabled = !isServiceRunning
+                            )
+                        }
+                        
+                        if (isStrictMode) {
+                            Spacer(modifier = Modifier.height(16.dp))
+                            Text(
+                                text = "Default Unlock Duration: $defaultUnlockDuration min",
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Slider(
+                                value = defaultUnlockDuration.toFloat(),
+                                onValueChange = { 
+                                    defaultUnlockDuration = it.toInt()
+                                    prefs.edit { putInt("default_unlock_duration", it.toInt()) }
+                                },
+                                valueRange = 1f..60f,
+                                steps = 59,
+                                enabled = !isServiceRunning
+                            )
+                        }
+                    }
+                }
+
+                // Primary action button — only shown when not monitoring OR in strict mode to stop via scan
                 if (!isServiceRunning) {
                     Button(
                         onClick = {
                             startMonitoringService(context)
-                            isServiceRunning = true
                         },
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(56.dp)
                     ) {
-                        Icon(
-                            imageVector = Icons.Default.PlayArrow,
-                            contentDescription = null
-                        )
+                        Icon(imageVector = Icons.Default.PlayArrow, contentDescription = null)
                         Spacer(modifier = Modifier.width(8.dp))
-                        Text(
-                            text = "Start Monitoring",
-                            style = MaterialTheme.typography.labelLarge
-                        )
+                        Text(text = "Start Monitoring", style = MaterialTheme.typography.labelLarge)
+                    }
+                } else {
+                    // Both modes require scanning to stop via the primary button
+                    Button(
+                        onClick = {
+                            if (hasCameraPermission) {
+                                qrCodeScannerLauncher.launch(ScanOptions().setOrientationLocked(true))
+                            } else {
+                                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                            }
+                        },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(56.dp),
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.secondary)
+                    ) {
+                        Icon(imageVector = Icons.Default.QrCodeScanner, contentDescription = null)
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(text = "Scan to Stop Monitoring", style = MaterialTheme.typography.labelLarge)
                     }
                 }
 
@@ -359,6 +502,15 @@ fun MainScreen() {
                         onClick = { settingsLauncher.launch(Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION)) }
                     ) {
                         Text("Grant Overlay Permission")
+                    }
+                }
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && !hasNotificationPermission) {
+                    Spacer(modifier = Modifier.height(12.dp))
+                    Button(
+                        modifier = Modifier.fillMaxWidth(),
+                        onClick = { notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS) }
+                    ) {
+                        Text("Grant Notification Permission")
                     }
                 }
             }

--- a/app/src/main/java/com/cj/tapblok/NfcHandlerActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/NfcHandlerActivity.kt
@@ -1,5 +1,8 @@
 package com.cj.tapblok
 
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
@@ -7,6 +10,7 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.core.app.NotificationCompat
 
 class NfcHandlerActivity : ComponentActivity() {
 
@@ -34,22 +38,65 @@ class NfcHandlerActivity : ComponentActivity() {
                     return
                 }
 
-                Log.d("NfcHandlerActivity", "Valid TapBlok NFC tag detected.")
+                val payload = String(record.payload, Charsets.UTF_8)
+                val prefs = getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+                val isStrictMode = prefs.getBoolean("is_strict_mode", false)
+                val isRunning = isServiceRunning(this, AppMonitoringService::class.java)
 
-                val serviceIntent = Intent(this, AppMonitoringService::class.java)
+                Log.d("NfcHandlerActivity", "Valid TapBlok NFC tag detected: $payload")
 
-                if (isServiceRunning(this, AppMonitoringService::class.java)) {
-                    // If the service is running, stop it.
-                    stopService(serviceIntent)
-                    Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
-                } else {
-                    // If the service is not running, start it.
-                    startMonitoringService(this)
-                    Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
+                val isToggle = payload == "TAPBLOK_TOGGLE"
+                val isUnlock = payload.startsWith("TAPBLOK_UNLOCK:")
+
+                if (isToggle || isUnlock) {
+                    if (!isStrictMode) {
+                        // Chill Mode: Always toggle
+                        val serviceIntent = Intent(this, AppMonitoringService::class.java)
+                        if (isRunning) {
+                            stopService(serviceIntent)
+                            Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+                        } else {
+                            startMonitoringService(this)
+                            Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
+                        }
+                    } else {
+                        // Strict Mode
+                        if (isRunning) {
+                            // Service is running, can't stop from background in Strict Mode
+                            showStrictWarningNotification()
+                            Toast.makeText(this, "Strict Mode: Open TapBlok to scan and stop.", Toast.LENGTH_LONG).show()
+                        } else {
+                            // Starting monitoring is always allowed
+                            startMonitoringService(this)
+                            Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
+                        }
+                    }
                 }
             }
         }
-        // Finish the activity immediately since it has no UI
         finish()
+    }
+
+    private fun showStrictWarningNotification() {
+        val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        val channelId = "tapblok_alerts"
+        
+        val intent = Intent(this, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+        }
+        val pendingIntent = PendingIntent.getActivity(
+            this, 0, intent, PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(this, channelId)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Strict Mode Active")
+            .setContentText("Tap to open TapBlok and scan your tag to stop monitoring.")
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setContentIntent(pendingIntent)
+            .setAutoCancel(true)
+            .build()
+
+        notificationManager.notify(1001, notification)
     }
 }

--- a/app/src/main/java/com/cj/tapblok/NfcWriteActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/NfcWriteActivity.kt
@@ -1,6 +1,7 @@
 package com.cj.tapblok
 
 import android.app.PendingIntent
+import android.content.Context
 import android.content.Intent
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
@@ -13,22 +14,12 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Nfc
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
@@ -43,7 +34,7 @@ class NfcWriteActivity : ComponentActivity() {
     }
 
     private var nfcAdapter: NfcAdapter? = null
-    private var ndefMessage: NdefMessage? = null
+    private var currentPayload = "TAPBLOK_TOGGLE"
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -55,57 +46,90 @@ class NfcWriteActivity : ComponentActivity() {
             return
         }
 
-        ndefMessage = createNdefMessage("work")
-
         setContent {
             TapBlokTheme {
-                Surface(modifier = Modifier.fillMaxSize()) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(32.dp),
-                        horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
-                    ) {
-                        Box(
-                            modifier = Modifier
-                                .size(120.dp)
-                                .background(
-                                    color = MaterialTheme.colorScheme.primaryContainer,
-                                    shape = CircleShape
-                                ),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            Icon(
-                                imageVector = Icons.Default.Nfc,
-                                contentDescription = null,
-                                modifier = Modifier.size(56.dp),
-                                tint = MaterialTheme.colorScheme.primary
-                            )
-                        }
-                        Spacer(modifier = Modifier.height(32.dp))
-                        Text(
-                            text = "Ready to Write",
-                            style = MaterialTheme.typography.headlineMedium
-                        )
-                        Spacer(modifier = Modifier.height(12.dp))
-                        Text(
-                            text = "Hold your NFC tag against the back of your phone.",
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            textAlign = TextAlign.Center
-                        )
-                        Spacer(modifier = Modifier.height(32.dp))
-                        CircularProgressIndicator(modifier = Modifier.size(32.dp))
-                    }
+                NfcWriteScreen(onPayloadChange = { currentPayload = it })
+            }
+        }
+    }
+
+    @Composable
+    fun NfcWriteScreen(onPayloadChange: (String) -> Unit) {
+        val prefs = remember { getSharedPreferences("app_prefs", Context.MODE_PRIVATE) }
+        var unlockDuration by remember { mutableStateOf(prefs.getInt("default_unlock_duration", 5)) }
+        var isToggleType by remember { mutableStateOf(true) }
+
+        LaunchedEffect(isToggleType, unlockDuration) {
+            onPayloadChange(if (isToggleType) "TAPBLOK_TOGGLE" else "TAPBLOK_UNLOCK:$unlockDuration")
+        }
+
+        Surface(modifier = Modifier.fillMaxSize()) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(32.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Box(
+                    modifier = Modifier
+                        .size(100.dp)
+                        .background(
+                            color = MaterialTheme.colorScheme.primaryContainer,
+                            shape = CircleShape
+                        ),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Nfc,
+                        contentDescription = null,
+                        modifier = Modifier.size(48.dp),
+                        tint = MaterialTheme.colorScheme.primary
+                    )
                 }
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "Write NFC Tag",
+                    style = MaterialTheme.typography.headlineMedium
+                )
+                
+                Spacer(modifier = Modifier.height(16.dp))
+                
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = isToggleType, onClick = { isToggleType = true })
+                    Text("Toggle Monitoring", modifier = Modifier.padding(start = 8.dp))
+                }
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    RadioButton(selected = !isToggleType, onClick = { isToggleType = false })
+                    Text("Temporary Unlock", modifier = Modifier.padding(start = 8.dp))
+                }
+
+                if (!isToggleType) {
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(text = "Unlock duration: $unlockDuration min")
+                    Slider(
+                        value = unlockDuration.toFloat(),
+                        onValueChange = { unlockDuration = it.toInt() },
+                        valueRange = 1f..60f,
+                        steps = 59
+                    )
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+                Text(
+                    text = "Hold your NFC tag against the back of your phone.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(24.dp))
+                CircularProgressIndicator(modifier = Modifier.size(32.dp))
             }
         }
     }
 
     override fun onResume() {
         super.onResume()
-        // Enable foreground dispatch to give this activity priority for NFC intents
         val intent = Intent(this, javaClass).addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
         val pendingIntent = PendingIntent.getActivity(this, 0, intent, PendingIntent.FLAG_MUTABLE)
         nfcAdapter?.enableForegroundDispatch(this, pendingIntent, null, null)
@@ -113,23 +137,21 @@ class NfcWriteActivity : ComponentActivity() {
 
     override fun onPause() {
         super.onPause()
-        // Disable foreground dispatch when the activity is not in the foreground
         nfcAdapter?.disableForegroundDispatch(this)
     }
 
-    // This method is called when an NFC tag is detected while the activity is in the foreground
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         val tag: Tag? = intent.getParcelableExtraCompat<Tag>(NfcAdapter.EXTRA_TAG)
-        if (tag != null && ndefMessage != null) {
-            writeNdefMessageToTag(ndefMessage!!, tag)
+        if (tag != null) {
+            val message = createNdefMessage(currentPayload)
+            writeNdefMessageToTag(message, tag)
             finish()
         }
     }
 
     private fun createNdefMessage(payload: String): NdefMessage {
-        val mimeType = NFC_MIME_TYPE
-        val mimeRecord = NdefRecord.createMime(mimeType, payload.toByteArray(Charsets.UTF_8))
+        val mimeRecord = NdefRecord.createMime(NFC_MIME_TYPE, payload.toByteArray(Charsets.UTF_8))
         return NdefMessage(arrayOf(mimeRecord))
     }
 
@@ -138,15 +160,6 @@ class NfcWriteActivity : ComponentActivity() {
         ndef?.use {
             try {
                 it.connect()
-                val messageBytes = message.toByteArray()
-                if (it.maxSize < messageBytes.size) {
-                    Toast.makeText(this, "Tag is too small!", Toast.LENGTH_SHORT).show()
-                    return
-                }
-                if (!it.isWritable) {
-                    Toast.makeText(this, "Tag is read-only!", Toast.LENGTH_SHORT).show()
-                    return
-                }
                 it.writeNdefMessage(message)
                 Toast.makeText(this, "Tag written successfully!", Toast.LENGTH_SHORT).show()
             } catch (e: IOException) {

--- a/app/src/main/java/com/cj/tapblok/QrCodeActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/QrCodeActivity.kt
@@ -1,5 +1,6 @@
 package com.cj.tapblok
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
@@ -7,16 +8,17 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.produceState
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.core.graphics.createBitmap
@@ -38,72 +40,117 @@ class QrCodeActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             TapBlokTheme {
-                Scaffold(
-                    topBar = {
-                        TopAppBar(
-                            title = { Text("Your QR Code") },
-                            navigationIcon = {
-                                IconButton(onClick = { finish() }) {
-                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
-                                }
-                            }
-                        )
-                    }
-                ) { padding ->
-                    QrCodeScreen(
-                        modifier = Modifier.padding(padding),
-                        content = QR_CODE_CONTENT
-                    )
-                }
+                QrCodeScreen(onBack = { finish() })
             }
         }
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun QrCodeScreen(modifier: Modifier = Modifier, content: String) {
-    val qrResult by produceState<Result<Bitmap>?>(initialValue = null, producer = {
+fun QrCodeScreen(onBack: () -> Unit) {
+    val context = LocalContext.current
+    val prefs = remember { context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE) }
+    var unlockDuration by remember { mutableStateOf(prefs.getInt("default_unlock_duration", 5)) }
+    var isToggleType by remember { mutableStateOf(true) }
+
+    val content = if (isToggleType) {
+        QrCodeActivity.QR_CODE_CONTENT
+    } else {
+        "TAPBLOK_UNLOCK:$unlockDuration"
+    }
+
+    val qrResult by produceState<Result<Bitmap>?>(initialValue = null, key1 = content) {
         value = withContext(Dispatchers.Default) {
             runCatching { generateQrCode(content) ?: error("Failed to generate QR code") }
         }
-    })
+    }
 
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(32.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        when (val result = qrResult) {
-            null -> CircularProgressIndicator()
-            else -> {
-                val bitmap = result.getOrNull()
-                if (bitmap != null) {
-                    Image(
-                        bitmap = bitmap.asImageBitmap(),
-                        contentDescription = "QR Code",
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .aspectRatio(1f),
-                        contentScale = ContentScale.Fit
-                    )
-                } else {
-                    Text(
-                        text = "Failed to generate QR code.",
-                        style = MaterialTheme.typography.bodyLarge,
-                        color = MaterialTheme.colorScheme.error,
-                        textAlign = TextAlign.Center
-                    )
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Your QR Code") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(32.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            when (val result = qrResult) {
+                null -> Box(modifier = Modifier.size(256.dp), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+                else -> {
+                    val bitmap = result.getOrNull()
+                    if (bitmap != null) {
+                        Image(
+                            bitmap = bitmap.asImageBitmap(),
+                            contentDescription = "QR Code",
+                            modifier = Modifier
+                                .size(256.dp)
+                                .aspectRatio(1f),
+                            contentScale = ContentScale.Fit
+                        )
+                    } else {
+                        Text(
+                            text = "Failed to generate QR code.",
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.error,
+                            textAlign = TextAlign.Center
+                        )
+                    }
                 }
             }
+
+            Spacer(modifier = Modifier.height(32.dp))
+
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Column(modifier = Modifier.padding(16.dp)) {
+                    Text(text = "Code Type", style = MaterialTheme.typography.titleMedium)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        RadioButton(selected = isToggleType, onClick = { isToggleType = true })
+                        Text("Toggle Monitoring", modifier = Modifier.padding(start = 8.dp))
+                    }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        RadioButton(selected = !isToggleType, onClick = { isToggleType = false })
+                        Text("Temporary Unlock", modifier = Modifier.padding(start = 8.dp))
+                    }
+
+                    if (!isToggleType) {
+                        Spacer(modifier = Modifier.height(16.dp))
+                        Text(text = "Unlock duration: $unlockDuration min")
+                        Slider(
+                            value = unlockDuration.toFloat(),
+                            onValueChange = { unlockDuration = it.toInt() },
+                            valueRange = 1f..60f,
+                            steps = 59
+                        )
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+            Text(
+                text = if (isToggleType)
+                    "Scan this code to start or stop a monitoring session."
+                else
+                    "Scan this code from a blocked app to unlock it for $unlockDuration minutes.",
+                style = MaterialTheme.typography.bodyMedium,
+                textAlign = TextAlign.Center,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
-        Spacer(modifier = Modifier.height(24.dp))
-        Text(
-            text = "Scan this code to start or stop a monitoring session.",
-            style = MaterialTheme.typography.bodyLarge,
-            textAlign = TextAlign.Center
-        )
     }
 }
 


### PR DESCRIPTION
This is quite a philosophy shift in the app so no pressure to merge or anything.

Added a toggle for strict mode vs chill mode:
Chill mode - same as original app.
Strict mode - no breaks, scanning NFC or QR on block page will only unlock that app for a set duration. Only way to unlock all apps / turn off monitoring is by opening app and scanning NFC or QR.

Added some notifications to show how much time is left when their apps are unlocked.

Notes for pull request
---
You won't want to merge this straight away. 

I'm not very familiar with Kotlin so used AI to program most of my changes and there seems to be a few flaws.
There are a few things android studio warned about and some un-needed variables and declarations.

More importantly, I had to mess with (remove) the signing code in app/build.gradle.kts to get my android studio to be happy compiling the project. 

Also worth noting I have updated the readme a bit for those going straight to my fork in the event this doesn't get merged.