### PR TITLE
fix: dedupe app list by package to prevent LazyColumn key collision

### DIFF
--- a/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
@@ -94,7 +94,8 @@ class AppSelectionViewModel(private val blockedAppDao: BlockedAppDao, private va
                     android.util.Log.w("AppSelectionViewModel", "Skipping $packageName: ${e.message}")
                     null
                 }
-            }.sortedBy { it.appName.lowercase() }
+            }.distinctBy { it.packageName }
+                .sortedBy { it.appName.lowercase() }
 
             blockedAppDao.getAllBlockedApps().collect { blockedApps ->
                 val blockedAppPackages = blockedApps.map { it.packageName }.toSet()


### PR DESCRIPTION
  ## Summary
  Apps that declare more than one `ACTION_MAIN` / `CATEGORY_LAUNCHER` activity (e.g. Tasker, with `net.dinglisch.android.taskerm`) cause
  `pm.queryIntentActivities()` to return multiple `ResolveInfo` entries for the same package. `AppSelectionViewModel.loadInstalledApps()` then produced
  duplicate `AppInfo` rows, and the `LazyColumn` in `AppSelectionActivity` — keyed on `packageName` — crashed with:

  java.lang.IllegalArgumentException: Key "net.dinglisch.android.taskerm" was already used.
  If you are using LazyColumn/Row please make sure you provide a unique key for each item.

  The screen crashed on entry for anyone with such an app installed.

  Fix: add `.distinctBy { it.packageName }` before sorting, in `AppSelectionActivity.kt`. Label/icon are package-scoped so collapsing extra launcher entries
   doesn't lose information.

  ## Test plan
  - [x] Reproduced on a device with Tasker installed (logcat above).
  - [x] After fix, **Manage Blocked Apps** opens with a single Tasker row.