### PR TITLE
v1.3.0: Fix Manage Blocked Apps crashes, service reliability, add app search

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.cj.tapblok"
         minSdk = 24
         targetSdk = 36
-        versionCode = 4
-        versionName = "1.2.1"
+        versionCode = 5
+        versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
 
     <uses-permission android:name="android.permission.NFC" />

--- a/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
+++ b/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
@@ -1,10 +1,13 @@
 package com.cj.tapblok
 
+import android.app.AlarmManager
 import android.app.PendingIntent
 import android.app.Service
+import android.app.usage.UsageEvents
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import android.os.CountDownTimer
 import android.os.IBinder
 import android.provider.Settings
@@ -28,11 +31,14 @@ class AppMonitoringService : Service() {
     @Volatile private var isBreakActive = false
     private var isMonitoring = false
     private var breakTimer: CountDownTimer? = null
+    private var lastEventTimestamp = 0L
+    private var currentForegroundApp: String? = null
 
     companion object {
         const val NOTIFICATION_ID = 1
         const val CHANNEL_ID = "app_monitoring_channel"
         const val ACTION_START_BREAK = "com.cj.tapblok.ACTION_START_BREAK"
+        private const val INITIAL_EVENT_LOOKBACK_MS = 60 * 60 * 1000L
         @Volatile var isRunning = false
     }
 
@@ -46,7 +52,9 @@ class AppMonitoringService : Service() {
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         if (intent?.action == ACTION_START_BREAK) {
             startBreak()
-            return START_NOT_STICKY
+            // The last onStartCommand return value governs restart-after-kill behaviour,
+            // so a break must not downgrade the service to non-sticky
+            return START_STICKY
         }
 
         Log.d("AppMonitoringService", "Service has started.")
@@ -145,19 +153,48 @@ class AppMonitoringService : Service() {
         Log.d("AppMonitoringService", "Service has been destroyed.")
     }
 
+    // Some launchers kill the process when the app's task is swiped away; schedule a
+    // restart so an active session survives "clear all apps"
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        if (prefs.getBoolean("monitoring_active", false)) {
+            val restartIntent = Intent(applicationContext, AppMonitoringService::class.java)
+            val flags = PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE
+            val pendingIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                PendingIntent.getForegroundService(this, 1, restartIntent, flags)
+            } else {
+                PendingIntent.getService(this, 1, restartIntent, flags)
+            }
+            val alarmManager = getSystemService(Context.ALARM_SERVICE) as AlarmManager
+            alarmManager.set(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 1000, pendingIntent)
+            Log.d("AppMonitoringService", "Task removed — scheduled service restart.")
+        }
+        super.onTaskRemoved(rootIntent)
+    }
+
     override fun onBind(intent: Intent): IBinder? {
         return null
     }
 
+    // Usage events are the reliable way to track the foreground app. queryUsageStats over a
+    // short window misses apps that were already in the foreground before the session began
+    // (no new stats update = invisible), which let blocked apps slip through.
+    @Suppress("DEPRECATION") // MOVE_TO_FOREGROUND == ACTIVITY_RESUMED; the old name also covers pre-API-29 devices
     private fun getForegroundApp(): String? {
         val usageStatsManager = getSystemService(Context.USAGE_STATS_SERVICE) as UsageStatsManager
-        val time = System.currentTimeMillis()
-        val appList = usageStatsManager.queryUsageStats(
-            UsageStatsManager.INTERVAL_DAILY,
-            time - 1000 * 10,
-            time
-        )
-        return appList?.maxByOrNull { it.lastTimeUsed }?.packageName
+        val now = System.currentTimeMillis()
+        val begin = if (lastEventTimestamp == 0L) now - INITIAL_EVENT_LOOKBACK_MS else lastEventTimestamp + 1
+        val events = usageStatsManager.queryEvents(begin, now)
+        val event = UsageEvents.Event()
+        while (events.hasNextEvent()) {
+            events.getNextEvent(event)
+            if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND) {
+                currentForegroundApp = event.packageName
+            }
+            if (event.timeStamp > lastEventTimestamp) {
+                lastEventTimestamp = event.timeStamp
+            }
+        }
+        return currentForegroundApp
     }
 }
 

--- a/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
@@ -2,6 +2,7 @@ package com.cj.tapblok
 
 import android.app.Application
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -20,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -94,7 +97,12 @@ class AppSelectionViewModel(private val blockedAppDao: BlockedAppDao, private va
                     android.util.Log.w("AppSelectionViewModel", "Skipping $packageName: ${e.message}")
                     null
                 }
-            }.sortedBy { it.appName.lowercase() }
+            }
+                // queryIntentActivities returns one entry per launcher activity, so packages
+                // with multiple launcher entries (Tasker, some OEM apps) would duplicate the
+                // LazyColumn key and crash
+                .distinctBy { it.packageName }
+                .sortedBy { it.appName.lowercase() }
 
             blockedAppDao.getAllBlockedApps().collect { blockedApps ->
                 val blockedAppPackages = blockedApps.map { it.packageName }.toSet()
@@ -205,15 +213,33 @@ fun AppSelectionScreen(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
-    LazyColumn(modifier = modifier.padding(all = 8.dp)) {
-        items(apps, key = { it.packageName }) { app ->
-            AppListItem(
-                app = app,
-                onCheckedChange = { isSelected ->
-                    onAppCheckedChange(app, isSelected)
-                },
-                isEnabled = !isServiceRunning
-            )
+    var searchQuery by rememberSaveable { mutableStateOf("") }
+    val filteredApps = remember(apps, searchQuery) {
+        if (searchQuery.isBlank()) apps
+        else apps.filter { it.appName.contains(searchQuery.trim(), ignoreCase = true) }
+    }
+
+    Column(modifier = modifier.padding(all = 8.dp)) {
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = { searchQuery = it },
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            placeholder = { Text("Search apps") },
+            leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
+            singleLine = true
+        )
+        LazyColumn {
+            items(filteredApps, key = { it.packageName }) { app ->
+                AppListItem(
+                    app = app,
+                    onCheckedChange = { isSelected ->
+                        onAppCheckedChange(app, isSelected)
+                    },
+                    isEnabled = !isServiceRunning
+                )
+            }
         }
     }
 }
@@ -225,6 +251,15 @@ fun AppListItem(
     isEnabled: Boolean
 ) {
     val context = LocalContext.current
+    // Loaded once per row; the app can be uninstalled between list load and render,
+    // in which case getApplicationIcon throws
+    val appIcon = remember(app.packageName) {
+        try {
+            context.packageManager.getApplicationIcon(app.packageName)
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
+        }
+    }
     Row(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier
@@ -235,7 +270,7 @@ fun AppListItem(
         Image(
             painter = rememberAsyncImagePainter(
                 model = ImageRequest.Builder(context)
-                    .data(context.packageManager.getApplicationIcon(app.packageName))
+                    .data(appIcon)
                     .build()
             ),
             contentDescription = "${app.appName} icon",

--- a/app/src/main/java/com/cj/tapblok/MainActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/MainActivity.kt
@@ -4,6 +4,7 @@ import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.widget.Toast
@@ -95,6 +96,22 @@ fun MainScreen() {
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted -> hasCameraPermission = isGranted }
 
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { }
+
+    // Without POST_NOTIFICATIONS on Android 13+ the persistent "TapBlok is Active"
+    // notification never shows, leaving users with no visible running indicator
+    LaunchedEffect(Unit) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.POST_NOTIFICATIONS
+            ) != PackageManager.PERMISSION_GRANTED
+        ) {
+            notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+        }
+    }
+
     val qrCodeScannerLauncher = rememberLauncherForActivityResult(
         contract = ScanContract()
     ) { result ->
@@ -120,6 +137,14 @@ fun MainScreen() {
                 canDrawOverlays = Settings.canDrawOverlays(context)
                 isServiceRunning = isServiceRunning(context, AppMonitoringService::class.java)
                 val prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+                // If the OS killed the service mid-session (task swiped away, OEM task
+                // killer), monitoring_active is still true — resume the session silently
+                if (!isServiceRunning && prefs.getBoolean("monitoring_active", false) &&
+                    hasUsagePermission && canDrawOverlays
+                ) {
+                    startMonitoringService(context)
+                    isServiceRunning = true
+                }
                 blockedAppAttempts = prefs.getInt("blocked_app_attempts", 0)
                 hasCameraPermission = ContextCompat.checkSelfPermission(
                     context, Manifest.permission.CAMERA


### PR DESCRIPTION
## What this fixes

### Manage Blocked Apps crash (fixes #11, fixes #12, fixes #14)
`queryIntentActivities` returns one entry per launcher **activity**, not per package. Apps with multiple launcher entries (Tasker, various MIUI/OnePlus/Samsung system apps) produced duplicate `LazyColumn` keys and crashed with `IllegalArgumentException: Key was already used` the moment the duplicate scrolled into view. The "special character" correlation in #12/#16 was coincidental — the crash was always the duplicate key. Now deduped by package name (thanks @bbendes for the exact diagnosis in #14). Icons are also now loaded once per row inside a try/catch, so an app being uninstalled mid-session can no longer crash the list.

### Blocking dies when the app is closed / app already open (fixes #20)
Four related fixes:
- Foreground detection now uses `UsageStatsManager.queryEvents` instead of `queryUsageStats` over a 10s window. The old approach missed apps that were **already** in the foreground when the session started ("YouTube has to be forced-stopped prior" in the report).
- `onTaskRemoved` now schedules a service restart, so sessions survive "clear all apps" on launchers that kill the process.
- Reopening TapBlok now silently resumes a session the OS killed (`monitoring_active` still set but service dead).
- "Take a Break" returned `START_NOT_STICKY`, permanently downgrading the service's restart-after-kill protection after the first break. Now stays sticky.

### App search (fixes #21)
Search field above the app list, filters by name as you type.

### Also
- Requests `POST_NOTIFICATIONS` on Android 13+ so the persistent "TapBlok is Active" notification is actually visible.
- Version bumped to 1.3.0 (versionCode 5).

Verified: `assembleDebug` builds clean.