### PR TITLE
v1.4.0: Settings screen, scheduled blocking, and automation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@
 - **🏷️ NFC Tag Support** — Write TapBlok's token to any NTAG213 tag (under $1 each). Tap to toggle a session.
 - **📷 QR Code Support** — Generate a QR code in-app and print it. Hide it somewhere that requires real effort to reach.
 - **🔒 Block Any App** — Choose any launchable app on your device. Critical system apps (dialer, settings, launcher) are permanently excluded so you can't lock yourself out.
-- **☕ Smart Breaks** — Take up to 3 five-minute breaks per session without ending it.
+- **☕ Smart Breaks** — Take five-minute breaks without ending the session. Choose how many per session (0–5) in Settings.
 - **🔁 Boot Persistence** — If your device restarts mid-session, TapBlok picks right back up.
-- **🚨 Emergency Override** — Lost your tag? A 90-second hold gives you a last resort exit — slow enough to stop impulse bypassing.
+- **🚨 Emergency Override** — Lost your tag? A hold-to-stop last resort. Set the hold anywhere from 30 seconds to 15 minutes, or disable it entirely for strict sessions.
+- **⏰ Scheduled Blocking** — Sessions start (and optionally stop) automatically on the days and times you choose.
+- **🤖 Automation Ready** — Opt-in broadcast actions let Tasker, MacroDroid, or Samsung Routines start and stop sessions.
 - **📊 Attempt Counter** — See how many times you tried to open a blocked app. Accountability you can't ignore.
 - **⚡ App Shortcut** — Long-press the TapBlok icon to start a session instantly.
 - **🔓 Open Source** — Every line of code is on GitHub. No black boxes, ever.
@@ -78,6 +80,24 @@ Any NDEF-compatible NFC tag works. Personally, I use and recommend these [NTAG21
 1. Tap **Show QR Code** in the app
 2. Screenshot or print it
 3. Put it somewhere that requires getting up — another room, your wallet, your desk drawer
+
+### Scheduled Blocking
+
+Open **Settings → Scheduled Blocking** to start sessions automatically — pick a start time, an optional auto-stop time, and the days of the week. Overnight windows (e.g. 22:00–07:00) work, and schedules survive reboots.
+
+### Automation (Tasker, MacroDroid, Samsung Routines)
+
+Enable **Settings → Allow automation apps**, then have your automation app send a broadcast:
+
+```
+# Start a session
+am broadcast -n com.cj.tapblok/.ScheduleReceiver -a com.cj.tapblok.SCHEDULE_START
+
+# Stop a session
+am broadcast -n com.cj.tapblok/.ScheduleReceiver -a com.cj.tapblok.SCHEDULE_STOP
+```
+
+In Tasker: **System → Send Intent** with Action `com.cj.tapblok.SCHEDULE_START` (or `SCHEDULE_STOP`), Package `com.cj.tapblok`, Class `com.cj.tapblok.ScheduleReceiver`, Target `Broadcast Receiver`. This opens up location-based blocking, calendar-triggered sessions, and similar automations. External triggers are ignored unless the toggle is on.
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.cj.tapblok"
         minSdk = 24
         targetSdk = 36
-        versionCode = 5
-        versionName = "1.3.0"
+        versionCode = 6
+        versionName = "1.4.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,6 +15,12 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Exact alarms for scheduled blocking: SCHEDULE_EXACT_ALARM covers Android 12/12L,
+         USE_EXACT_ALARM (auto-granted) covers 13+ -->
+    <uses-permission
+        android:name="android.permission.SCHEDULE_EXACT_ALARM"
+        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <uses-permission android:name="android.permission.NFC" />
 
@@ -83,6 +89,11 @@
             android:label="@string/title_activity_qr_code"
             android:theme="@style/Theme.TapBlok" />
         <activity
+            android:name=".SettingsActivity"
+            android:exported="false"
+            android:label="@string/title_activity_settings"
+            android:theme="@style/Theme.TapBlok" />
+        <activity
             android:name="com.journeyapps.barcodescanner.CaptureActivity"
             android:screenOrientation="portrait"
             tools:replace="screenOrientation" />
@@ -101,6 +112,18 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
+            </intent-filter>
+        </receiver>
+
+        <!-- Exported so automation apps (Tasker, MacroDroid, Samsung Routines) can start
+             or stop sessions; external triggers are ignored unless the user enables
+             "Allow automation apps" in Settings. Also the target of schedule alarms. -->
+        <receiver
+            android:name=".ScheduleReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="com.cj.tapblok.SCHEDULE_START" />
+                <action android:name="com.cj.tapblok.SCHEDULE_STOP" />
             </intent-filter>
         </receiver>
     </application>

--- a/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
+++ b/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
@@ -60,7 +60,7 @@ class AppMonitoringService : Service() {
         Log.d("AppMonitoringService", "Service has started.")
 
         prefs.edit {
-            putInt("breaks_remaining", 3)
+            putInt("breaks_remaining", prefs.getInt(AppSettings.KEY_BREAKS_ALLOWED, AppSettings.DEFAULT_BREAKS_ALLOWED))
             putInt("blocked_app_attempts", 0)
             putBoolean("monitoring_active", true)
         }

--- a/app/src/main/java/com/cj/tapblok/BootCompletedReceiver.kt
+++ b/app/src/main/java/com/cj/tapblok/BootCompletedReceiver.kt
@@ -13,8 +13,13 @@ class BootCompletedReceiver : BroadcastReceiver() {
             if (prefs.getBoolean("monitoring_active", false)) {
                 Log.d("BootCompletedReceiver", "Boot completed, resuming monitoring service.")
                 startMonitoringService(context)
+                // Alarms don't survive reboot; recompute them
+                ScheduleManager.reschedule(context)
             } else {
                 Log.d("BootCompletedReceiver", "Boot completed, monitoring was not active — skipping auto-start.")
+                // Recompute alarms, and start blocking if we're inside a scheduled window
+                // whose start alarm was missed while the phone was off
+                ScheduleManager.reschedule(context, startIfInWindow = true)
             }
         }
     }

--- a/app/src/main/java/com/cj/tapblok/MainActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/MainActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.QrCode2
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Security
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
@@ -80,6 +81,10 @@ fun MainScreen() {
             ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA) == PackageManager.PERMISSION_GRANTED
         )
     }
+
+    val appPrefs = remember { AppSettings.prefs(context) }
+    var overrideEnabled by remember { mutableStateOf(appPrefs.getBoolean(AppSettings.KEY_OVERRIDE_ENABLED, true)) }
+    var overrideSeconds by remember { mutableStateOf(appPrefs.getInt(AppSettings.KEY_OVERRIDE_SECONDS, AppSettings.DEFAULT_OVERRIDE_SECONDS)) }
 
     var holdProgress by remember { mutableStateOf(0f) }
     var isHolding by remember { mutableStateOf(false) }
@@ -146,6 +151,8 @@ fun MainScreen() {
                     isServiceRunning = true
                 }
                 blockedAppAttempts = prefs.getInt("blocked_app_attempts", 0)
+                overrideEnabled = prefs.getBoolean(AppSettings.KEY_OVERRIDE_ENABLED, true)
+                overrideSeconds = prefs.getInt(AppSettings.KEY_OVERRIDE_SECONDS, AppSettings.DEFAULT_OVERRIDE_SECONDS)
                 hasCameraPermission = ContextCompat.checkSelfPermission(
                     context, Manifest.permission.CAMERA
                 ) == PackageManager.PERMISSION_GRANTED
@@ -158,7 +165,7 @@ fun MainScreen() {
     LaunchedEffect(isHolding) {
         if (isHolding) {
             val startTime = System.currentTimeMillis()
-            val duration = 90000L
+            val duration = overrideSeconds * 1000L
             while (isHolding && System.currentTimeMillis() - startTime < duration) {
                 holdProgress = (System.currentTimeMillis() - startTime) / duration.toFloat()
                 delay(50)
@@ -297,11 +304,17 @@ fun MainScreen() {
                                 }
                             }
                         )
+                        HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                        ActionRow(
+                            icon = Icons.Default.Tune,
+                            label = "Settings",
+                            onClick = { context.startActivity(Intent(context, SettingsActivity::class.java)) }
+                        )
                     }
                 }
 
                 // Emergency stop
-                if (isServiceRunning) {
+                if (isServiceRunning && overrideEnabled) {
                     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
                         Text(
                             text = "Emergency Override",
@@ -329,8 +342,9 @@ fun MainScreen() {
                                 color = MaterialTheme.colorScheme.error,
                                 trackColor = MaterialTheme.colorScheme.errorContainer
                             )
+                            val overrideLabel = if (overrideSeconds % 60 == 0) "${overrideSeconds / 60}m" else "${overrideSeconds}s"
                             Text(
-                                text = "HOLD 90s TO FORCE STOP",
+                                text = "HOLD $overrideLabel TO FORCE STOP",
                                 modifier = Modifier.align(Alignment.Center),
                                 style = MaterialTheme.typography.labelMedium,
                                 color = if (holdProgress > 0.5f) MaterialTheme.colorScheme.onError

--- a/app/src/main/java/com/cj/tapblok/ScheduleManager.kt
+++ b/app/src/main/java/com/cj/tapblok/ScheduleManager.kt
@@ -1,0 +1,129 @@
+package com.cj.tapblok
+
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+import java.util.Calendar
+
+/**
+ * Schedules the start/stop alarms for scheduled blocking sessions. All state lives in
+ * SharedPreferences (see AppSettings); reschedule() is idempotent and recomputes both
+ * alarms from scratch, so it is safe to call from settings changes, boot, and alarm fires.
+ */
+object ScheduleManager {
+
+    private const val TAG = "ScheduleManager"
+    private const val REQUEST_START = 100
+    private const val REQUEST_STOP = 101
+    private const val MINUTES_PER_DAY = 24 * 60
+
+    /**
+     * @param startIfInWindow when true and "now" falls inside an active schedule window,
+     * the session starts immediately (used on settings save and boot so a missed start
+     * alarm still results in blocking). Alarm-fire paths pass false so a manual stop
+     * during a window isn't immediately re-started.
+     */
+    fun reschedule(context: Context, startIfInWindow: Boolean = false) {
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        val startPi = pendingIntent(context, REQUEST_START, ScheduleReceiver.ACTION_SCHEDULE_START)
+        val stopPi = pendingIntent(context, REQUEST_STOP, ScheduleReceiver.ACTION_SCHEDULE_STOP)
+        alarmManager.cancel(startPi)
+        alarmManager.cancel(stopPi)
+
+        val prefs = AppSettings.prefs(context)
+        if (!prefs.getBoolean(AppSettings.KEY_SCHEDULE_ENABLED, false)) return
+        val daysMask = prefs.getInt(AppSettings.KEY_SCHEDULE_DAYS, AppSettings.DEFAULT_DAYS_MASK)
+        if (daysMask == 0) return
+
+        val startMinutes = prefs.getInt(AppSettings.KEY_SCHEDULE_START_MINUTES, AppSettings.DEFAULT_START_MINUTES)
+        val stopEnabled = prefs.getBoolean(AppSettings.KEY_SCHEDULE_STOP_ENABLED, true)
+        val stopMinutes = prefs.getInt(AppSettings.KEY_SCHEDULE_STOP_MINUTES, AppSettings.DEFAULT_STOP_MINUTES)
+        // A stop time equal to the start time would make a zero-length window; treat it
+        // as no auto-stop rather than guessing 24h
+        val windowMinutes = if (stopEnabled) ((stopMinutes - startMinutes) + MINUTES_PER_DAY) % MINUTES_PER_DAY else 0
+
+        val now = System.currentTimeMillis()
+
+        val currentWindowStart = currentWindowStartMillis(now, daysMask, startMinutes, windowMinutes)
+        if (currentWindowStart != null) {
+            if (startIfInWindow && !isServiceRunning(context, AppMonitoringService::class.java)) {
+                Log.d(TAG, "Inside a scheduled window — starting session now.")
+                startMonitoringService(context)
+            }
+            setAlarm(context, alarmManager, stopPi, currentWindowStart + windowMinutes * 60_000L)
+        }
+
+        val nextStart = nextStartMillis(now, daysMask, startMinutes)
+        if (nextStart != null) {
+            setAlarm(context, alarmManager, startPi, nextStart)
+            Log.d(TAG, "Next scheduled start: ${java.util.Date(nextStart)}")
+        }
+    }
+
+    private fun pendingIntent(context: Context, requestCode: Int, action: String): PendingIntent {
+        val intent = Intent(context, ScheduleReceiver::class.java)
+            .setAction(action)
+            .putExtra(ScheduleReceiver.EXTRA_FROM_ALARM, true)
+        return PendingIntent.getBroadcast(
+            context, requestCode, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    private fun setAlarm(context: Context, alarmManager: AlarmManager, operation: PendingIntent, triggerAt: Long) {
+        try {
+            // setAlarmClock fires exactly even in Doze/battery saver, and puts the app on
+            // the temporary allowlist so the receiver may start the foreground service
+            val showIntent = PendingIntent.getActivity(
+                context, 0, Intent(context, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE
+            )
+            alarmManager.setAlarmClock(AlarmManager.AlarmClockInfo(triggerAt, showIntent), operation)
+        } catch (e: SecurityException) {
+            // Exact-alarm permission revoked by the user; an inexact alarm beats none
+            Log.w(TAG, "Exact alarm not permitted, falling back to inexact.", e)
+            alarmManager.setAndAllowWhileIdle(AlarmManager.RTC_WAKEUP, triggerAt, operation)
+        }
+    }
+
+    // Bit 0 = Monday … bit 6 = Sunday; Calendar.DAY_OF_WEEK has Sunday=1 … Saturday=7
+    private fun dayBit(calendar: Calendar): Int = (calendar.get(Calendar.DAY_OF_WEEK) + 5) % 7
+
+    private fun dayEnabled(calendar: Calendar, daysMask: Int): Boolean =
+        daysMask and (1 shl dayBit(calendar)) != 0
+
+    private fun atMinutesOfDay(base: Calendar, minutesOfDay: Int): Calendar =
+        (base.clone() as Calendar).apply {
+            set(Calendar.HOUR_OF_DAY, minutesOfDay / 60)
+            set(Calendar.MINUTE, minutesOfDay % 60)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+
+    private fun nextStartMillis(now: Long, daysMask: Int, startMinutes: Int): Long? {
+        val base = Calendar.getInstance().apply { timeInMillis = now }
+        for (dayOffset in 0..7) {
+            val candidate = atMinutesOfDay(base, startMinutes).apply { add(Calendar.DAY_OF_YEAR, dayOffset) }
+            if (candidate.timeInMillis > now && dayEnabled(candidate, daysMask)) {
+                return candidate.timeInMillis
+            }
+        }
+        return null
+    }
+
+    // Windows are anchored to their start day and never exceed 24h, so only today's and
+    // yesterday's start times can contain "now" (yesterday's covers overnight windows)
+    private fun currentWindowStartMillis(now: Long, daysMask: Int, startMinutes: Int, windowMinutes: Int): Long? {
+        if (windowMinutes <= 0) return null
+        val base = Calendar.getInstance().apply { timeInMillis = now }
+        for (dayOffset in 0 downTo -1) {
+            val candidate = atMinutesOfDay(base, startMinutes).apply { add(Calendar.DAY_OF_YEAR, dayOffset) }
+            val start = candidate.timeInMillis
+            if (dayEnabled(candidate, daysMask) && now >= start && now < start + windowMinutes * 60_000L) {
+                return start
+            }
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/cj/tapblok/ScheduleReceiver.kt
+++ b/app/src/main/java/com/cj/tapblok/ScheduleReceiver.kt
@@ -1,0 +1,55 @@
+package com.cj.tapblok
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.util.Log
+
+/**
+ * Handles scheduled-blocking alarms, and doubles as the entry point for external
+ * automation apps (Tasker, MacroDroid, Samsung Routines): they can broadcast
+ * SCHEDULE_START / SCHEDULE_STOP at this component when the user has enabled
+ * "Allow automation apps" in Settings.
+ *
+ * Note: EXTRA_FROM_ALARM is a routing flag, not a security boundary — this is an
+ * open-source self-control app, and anyone determined enough to fake the extra
+ * could also just uninstall the app. The automation toggle exists so blocking
+ * can't be toggled by other apps unless the user opted in.
+ */
+class ScheduleReceiver : BroadcastReceiver() {
+
+    companion object {
+        const val ACTION_SCHEDULE_START = "com.cj.tapblok.SCHEDULE_START"
+        const val ACTION_SCHEDULE_STOP = "com.cj.tapblok.SCHEDULE_STOP"
+        const val EXTRA_FROM_ALARM = "com.cj.tapblok.extra.FROM_ALARM"
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val fromAlarm = intent.getBooleanExtra(EXTRA_FROM_ALARM, false)
+        val prefs = AppSettings.prefs(context)
+
+        if (!fromAlarm && !prefs.getBoolean(AppSettings.KEY_EXTERNAL_AUTOMATION, false)) {
+            Log.w("ScheduleReceiver", "External trigger ignored — automation is disabled in Settings.")
+            return
+        }
+
+        when (intent.action) {
+            ACTION_SCHEDULE_START -> {
+                if (!isServiceRunning(context, AppMonitoringService::class.java)) {
+                    Log.d("ScheduleReceiver", "Starting session (${if (fromAlarm) "schedule" else "automation"}).")
+                    startMonitoringService(context)
+                }
+            }
+            ACTION_SCHEDULE_STOP -> {
+                Log.d("ScheduleReceiver", "Stopping session (${if (fromAlarm) "schedule" else "automation"}).")
+                context.stopService(Intent(context, AppMonitoringService::class.java))
+            }
+            else -> return
+        }
+
+        if (fromAlarm) {
+            // Chain the next occurrence; alarm fires are one-shot
+            ScheduleManager.reschedule(context)
+        }
+    }
+}

--- a/app/src/main/java/com/cj/tapblok/SettingsActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/SettingsActivity.kt
@@ -1,0 +1,361 @@
+package com.cj.tapblok
+
+import android.app.TimePickerDialog
+import android.content.Context
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
+import com.cj.tapblok.ui.theme.TapBlokTheme
+import java.util.Locale
+
+object AppSettings {
+    const val PREFS_NAME = "app_prefs"
+
+    const val KEY_OVERRIDE_ENABLED = "override_enabled"
+    const val KEY_OVERRIDE_SECONDS = "override_seconds"
+    const val KEY_BREAKS_ALLOWED = "breaks_allowed"
+    const val KEY_EXTERNAL_AUTOMATION = "external_automation_enabled"
+    const val KEY_SCHEDULE_ENABLED = "schedule_enabled"
+    const val KEY_SCHEDULE_START_MINUTES = "schedule_start_minutes"
+    const val KEY_SCHEDULE_STOP_ENABLED = "schedule_stop_enabled"
+    const val KEY_SCHEDULE_STOP_MINUTES = "schedule_stop_minutes"
+    // Bit 0 = Monday … bit 6 = Sunday
+    const val KEY_SCHEDULE_DAYS = "schedule_days"
+
+    const val DEFAULT_OVERRIDE_SECONDS = 90
+    const val DEFAULT_BREAKS_ALLOWED = 3
+    const val DEFAULT_START_MINUTES = 22 * 60
+    const val DEFAULT_STOP_MINUTES = 7 * 60
+    const val DEFAULT_DAYS_MASK = 0b1111111
+
+    fun prefs(context: Context): android.content.SharedPreferences =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun formatMinutesOfDay(minutesOfDay: Int): String =
+        String.format(Locale.US, "%02d:%02d", minutesOfDay / 60, minutesOfDay % 60)
+}
+
+class SettingsActivity : ComponentActivity() {
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            TapBlokTheme {
+                Scaffold(
+                    topBar = {
+                        TopAppBar(
+                            title = { Text("Settings") },
+                            navigationIcon = {
+                                IconButton(onClick = { finish() }) {
+                                    Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")
+                                }
+                            }
+                        )
+                    }
+                ) { padding ->
+                    SettingsScreen(modifier = Modifier.padding(padding))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SettingsScreen(modifier: Modifier = Modifier) {
+    val context = LocalContext.current
+    val prefs = remember { AppSettings.prefs(context) }
+
+    var isServiceActive by remember { mutableStateOf(isServiceRunning(context, AppMonitoringService::class.java)) }
+
+    var overrideEnabled by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_OVERRIDE_ENABLED, true)) }
+    var overrideSeconds by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_OVERRIDE_SECONDS, AppSettings.DEFAULT_OVERRIDE_SECONDS)) }
+    var breaksAllowed by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_BREAKS_ALLOWED, AppSettings.DEFAULT_BREAKS_ALLOWED)) }
+    var externalAutomation by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_EXTERNAL_AUTOMATION, false)) }
+    var scheduleEnabled by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_SCHEDULE_ENABLED, false)) }
+    var startMinutes by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_SCHEDULE_START_MINUTES, AppSettings.DEFAULT_START_MINUTES)) }
+    var stopEnabled by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_SCHEDULE_STOP_ENABLED, true)) }
+    var stopMinutes by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_SCHEDULE_STOP_MINUTES, AppSettings.DEFAULT_STOP_MINUTES)) }
+    var daysMask by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_SCHEDULE_DAYS, AppSettings.DEFAULT_DAYS_MASK)) }
+
+    // All inputs lock while a session runs so settings can't be loosened mid-session
+    val editable = !isServiceActive
+
+    fun rescheduleAlarms() = ScheduleManager.reschedule(context, startIfInWindow = true)
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(bottom = 32.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        if (isServiceActive) {
+            ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = "Settings are locked while a session is active.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                    modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+
+        SettingsSection(title = "Emergency Override") {
+            SettingsSwitchRow(
+                label = "Enable emergency override",
+                caption = "Hold-to-stop button shown during a session",
+                checked = overrideEnabled,
+                enabled = editable,
+                onCheckedChange = {
+                    overrideEnabled = it
+                    prefs.edit { putBoolean(AppSettings.KEY_OVERRIDE_ENABLED, it) }
+                }
+            )
+            if (overrideEnabled) {
+                Text(
+                    text = "Hold duration",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf(30 to "30s", 90 to "90s", 300 to "5m", 900 to "15m").forEach { (seconds, label) ->
+                        FilterChip(
+                            selected = overrideSeconds == seconds,
+                            enabled = editable,
+                            onClick = {
+                                overrideSeconds = seconds
+                                prefs.edit { putInt(AppSettings.KEY_OVERRIDE_SECONDS, seconds) }
+                            },
+                            label = { Text(label) }
+                        )
+                    }
+                }
+            } else {
+                Text(
+                    text = "With the override disabled, only your NFC tag or QR code can stop a session.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        }
+
+        SettingsSection(title = "Breaks") {
+            Text(
+                text = "Breaks allowed per session",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                listOf(0 to "None", 1 to "1", 3 to "3", 5 to "5").forEach { (count, label) ->
+                    FilterChip(
+                        selected = breaksAllowed == count,
+                        enabled = editable,
+                        onClick = {
+                            breaksAllowed = count
+                            prefs.edit { putInt(AppSettings.KEY_BREAKS_ALLOWED, count) }
+                        },
+                        label = { Text(label) }
+                    )
+                }
+            }
+        }
+
+        SettingsSection(title = "Scheduled Blocking") {
+            SettingsSwitchRow(
+                label = "Start sessions on a schedule",
+                caption = "Blocking begins automatically, no tag needed",
+                checked = scheduleEnabled,
+                enabled = editable,
+                onCheckedChange = {
+                    scheduleEnabled = it
+                    prefs.edit { putBoolean(AppSettings.KEY_SCHEDULE_ENABLED, it) }
+                    rescheduleAlarms()
+                }
+            )
+            if (scheduleEnabled) {
+                TimeRow(
+                    label = "Start time",
+                    minutesOfDay = startMinutes,
+                    enabled = editable,
+                    onTimePicked = {
+                        startMinutes = it
+                        prefs.edit { putInt(AppSettings.KEY_SCHEDULE_START_MINUTES, it) }
+                        rescheduleAlarms()
+                    }
+                )
+                SettingsSwitchRow(
+                    label = "Auto-stop",
+                    caption = "End the session automatically",
+                    checked = stopEnabled,
+                    enabled = editable,
+                    onCheckedChange = {
+                        stopEnabled = it
+                        prefs.edit { putBoolean(AppSettings.KEY_SCHEDULE_STOP_ENABLED, it) }
+                        rescheduleAlarms()
+                    }
+                )
+                if (stopEnabled) {
+                    TimeRow(
+                        label = "Stop time",
+                        minutesOfDay = stopMinutes,
+                        enabled = editable,
+                        onTimePicked = {
+                            stopMinutes = it
+                            prefs.edit { putInt(AppSettings.KEY_SCHEDULE_STOP_MINUTES, it) }
+                            rescheduleAlarms()
+                        }
+                    )
+                }
+                Text(
+                    text = "Days",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(4.dp)) {
+                    val dayLabels = listOf("M", "T", "W", "T", "F", "S", "S")
+                    dayLabels.forEachIndexed { index, label ->
+                        val bit = 1 shl index
+                        FilterChip(
+                            selected = daysMask and bit != 0,
+                            enabled = editable,
+                            onClick = {
+                                daysMask = daysMask xor bit
+                                prefs.edit { putInt(AppSettings.KEY_SCHEDULE_DAYS, daysMask) }
+                                rescheduleAlarms()
+                            },
+                            label = { Text(label) }
+                        )
+                    }
+                }
+                if (daysMask == 0) {
+                    Text(
+                        text = "Select at least one day for the schedule to run.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error
+                    )
+                }
+            }
+        }
+
+        SettingsSection(title = "Automation") {
+            SettingsSwitchRow(
+                label = "Allow automation apps",
+                caption = "Tasker, MacroDroid, Samsung Routines and similar apps can start or stop " +
+                        "sessions by broadcasting com.cj.tapblok.SCHEDULE_START or SCHEDULE_STOP",
+                checked = externalAutomation,
+                enabled = editable,
+                onCheckedChange = {
+                    externalAutomation = it
+                    prefs.edit { putBoolean(AppSettings.KEY_EXTERNAL_AUTOMATION, it) }
+                }
+            )
+        }
+    }
+
+    // Re-check the lock when returning to the screen (e.g. a scheduled session started)
+    val lifecycleOwner = androidx.lifecycle.compose.LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = androidx.lifecycle.LifecycleEventObserver { _, event ->
+            if (event == androidx.lifecycle.Lifecycle.Event.ON_RESUME) {
+                isServiceActive = isServiceRunning(context, AppMonitoringService::class.java)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+}
+
+@Composable
+private fun SettingsSection(title: String, content: @Composable ColumnScope.() -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            text = title,
+            style = MaterialTheme.typography.labelLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.padding(top = 16.dp)
+        )
+        ElevatedCard(modifier = Modifier.fillMaxWidth()) {
+            Column(
+                modifier = Modifier.padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                content = content
+            )
+        }
+    }
+}
+
+@Composable
+private fun SettingsSwitchRow(
+    label: String,
+    caption: String,
+    checked: Boolean,
+    enabled: Boolean,
+    onCheckedChange: (Boolean) -> Unit
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Text(text = label, style = MaterialTheme.typography.bodyLarge)
+            Text(
+                text = caption,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+        Switch(checked = checked, onCheckedChange = onCheckedChange, enabled = enabled)
+    }
+}
+
+@Composable
+private fun TimeRow(
+    label: String,
+    minutesOfDay: Int,
+    enabled: Boolean,
+    onTimePicked: (Int) -> Unit
+) {
+    val context = LocalContext.current
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(enabled = enabled) {
+                TimePickerDialog(
+                    context,
+                    { _, hour, minute -> onTimePicked(hour * 60 + minute) },
+                    minutesOfDay / 60,
+                    minutesOfDay % 60,
+                    true
+                ).show()
+            }
+            .padding(vertical = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.weight(1f)
+        )
+        Text(
+            text = AppSettings.formatMinutesOfDay(minutesOfDay),
+            style = MaterialTheme.typography.bodyLarge,
+            color = if (enabled) MaterialTheme.colorScheme.primary
+                    else MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f)
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="shortcut_start_session_long_label">Start a new monitoring session</string>
     <string name="title_activity_qr_code">Your QR Code</string>
     <string name="title_activity_shortcut_handler">Start Monitoring</string>
+    <string name="title_activity_settings">Settings</string>
     <string name="shortcut_start_session_disabled">TapBlok monitoring shortcut is currently unavailable.</string>
 </resources>
 


### PR DESCRIPTION
## What this adds

### Settings screen (addresses the configurability asks in #13)
New Settings screen, reachable from the main menu. Everything locks while a session is active so limits can't be loosened mid-session.

- **Emergency override**: hold time configurable (30s / 90s / 5m / 15m) or disable the override entirely — then only the NFC tag or QR code can stop a session.
- **Breaks**: 0 / 1 / 3 / 5 breaks per session (0 removes the "Take a Break" button).

### Scheduled blocking (#22)
- Start time, optional auto-stop time, and day-of-week selection.
- Overnight windows (22:00–07:00) handled; alarms rescheduled after reboot; a start missed while powered off is recovered on boot.
- Uses `setAlarmClock` so schedules fire exactly even in Doze/battery saver. `USE_EXACT_ALARM` (13+) and `SCHEDULE_EXACT_ALARM` (12/12L) declared, with an inexact fallback if the permission is revoked — no crash-on-save.

### External automation (#22)
`ScheduleReceiver` is exported with the same action names proposed in the issue, so Tasker / MacroDroid / Samsung Routines recipes work:

```
am broadcast -n com.cj.tapblok/.ScheduleReceiver -a com.cj.tapblok.SCHEDULE_START
am broadcast -n com.cj.tapblok/.ScheduleReceiver -a com.cj.tapblok.SCHEDULE_STOP
```

Gated behind an **off-by-default** "Allow automation apps" toggle so other apps can't stop blocking unless the user opts in. Implemented from scratch — no code pulled from forks.

Verified: `assembleDebug` builds clean.