### PR TITLE
v1.5.0: Strict mode, per-install QR codes, mid-session credential lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@
 ## ✨ Features
 
 - **🏷️ NFC Tag Support** — Write TapBlok's token to any NTAG213 tag (under $1 each). Tap to toggle a session.
-- **📷 QR Code Support** — Generate a QR code in-app and print it. Hide it somewhere that requires real effort to reach.
+- **📷 QR Code Support** — Generate a QR code in-app and print it. Hide it somewhere that requires real effort to reach. Every install gets its own unique code.
+- **🔐 Strict Mode** — Sessions can only be stopped by scanning with TapBlok open. Scanning on a block screen grants a short timed unlock for that one app instead of ending the session.
 - **🔒 Block Any App** — Choose any launchable app on your device. Critical system apps (dialer, settings, launcher) are permanently excluded so you can't lock yourself out.
 - **☕ Smart Breaks** — Take five-minute breaks without ending the session. Choose how many per session (0–5) in Settings.
 - **🔁 Boot Persistence** — If your device restarts mid-session, TapBlok picks right back up.
@@ -80,6 +81,12 @@ Any NDEF-compatible NFC tag works. Personally, I use and recommend these [NTAG21
 1. Tap **Show QR Code** in the app
 2. Screenshot or print it
 3. Put it somewhere that requires getting up — another room, your wallet, your desk drawer
+
+> **Upgrading from before v1.5.0?** QR codes are now unique per install. Print a new one — codes from older versions (or other phones) no longer work.
+
+### Strict Mode
+
+Enable **Settings → Strict Mode** and a running session can only be stopped by opening TapBlok first, then scanning your tag or QR code. Scanning on a block screen doesn't end the session — it unlocks just that one app for a limited time (1–30 minutes, your choice). Combine with zero breaks and a disabled emergency override for maximum friction.
 
 ### Scheduled Blocking
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.cj.tapblok"
         minSdk = 24
         targetSdk = 36
-        versionCode = 6
-        versionName = "1.4.0"
+        versionCode = 7
+        versionName = "1.5.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/cj/tapblok/App.kt
+++ b/app/src/main/java/com/cj/tapblok/App.kt
@@ -1,10 +1,12 @@
 package com.cj.tapblok
 
+import android.app.Activity
 import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.os.Build
+import android.os.Bundle
 import com.cj.tapblok.database.AppDatabase
 
 class App : Application() {
@@ -13,6 +15,33 @@ class App : Application() {
     override fun onCreate() {
         super.onCreate()
         createNotificationChannel()
+        trackForegroundForStrictMode()
+    }
+
+    // Strict mode allows stopping a session only while the user is inside TapBlok.
+    // Any of our screens counts, except the invisible handlers and the block screen
+    // (which has its own tracking so tag scans there unlock a single app instead)
+    private fun trackForegroundForStrictMode() {
+        registerActivityLifecycleCallbacks(object : ActivityLifecycleCallbacks {
+            private fun isMainUi(activity: Activity): Boolean = when (activity) {
+                is BlockingActivity, is NfcHandlerActivity, is ShortcutHandlerActivity -> false
+                else -> true
+            }
+
+            override fun onActivityResumed(activity: Activity) {
+                if (isMainUi(activity)) AppForeground.onMainResumed()
+            }
+
+            override fun onActivityPaused(activity: Activity) {
+                if (isMainUi(activity)) AppForeground.onMainPaused()
+            }
+
+            override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {}
+            override fun onActivityStarted(activity: Activity) {}
+            override fun onActivityStopped(activity: Activity) {}
+            override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {}
+            override fun onActivityDestroyed(activity: Activity) {}
+        })
     }
 
     private fun createNotificationChannel() {

--- a/app/src/main/java/com/cj/tapblok/AppForeground.kt
+++ b/app/src/main/java/com/cj/tapblok/AppForeground.kt
@@ -1,0 +1,46 @@
+package com.cj.tapblok
+
+/**
+ * Tracks which TapBlok screens are currently visible so NfcHandlerActivity can tell a
+ * foreground scan from a background one in strict mode. The NFC intent pauses the
+ * underlying activity before the handler starts, so "paused a moment ago" still counts
+ * as foreground.
+ */
+object AppForeground {
+
+    private const val GRACE_MS = 5_000L
+
+    @Volatile private var mainResumed = false
+    @Volatile private var mainPausedAt = 0L
+    @Volatile private var blockingResumed = false
+    @Volatile private var blockingPausedAt = 0L
+
+    /** Package shown on the block screen, null when none is known. */
+    @Volatile var blockedPackage: String? = null
+        private set
+
+    fun onMainResumed() {
+        mainResumed = true
+    }
+
+    fun onMainPaused() {
+        mainResumed = false
+        mainPausedAt = System.currentTimeMillis()
+    }
+
+    fun onBlockingResumed(packageName: String?) {
+        blockingResumed = true
+        blockedPackage = packageName
+    }
+
+    fun onBlockingPaused() {
+        blockingResumed = false
+        blockingPausedAt = System.currentTimeMillis()
+    }
+
+    fun isMainVisible(): Boolean =
+        mainResumed || System.currentTimeMillis() - mainPausedAt < GRACE_MS
+
+    fun isBlockingVisible(): Boolean =
+        blockingResumed || System.currentTimeMillis() - blockingPausedAt < GRACE_MS
+}

--- a/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
+++ b/app/src/main/java/com/cj/tapblok/AppMonitoringService.kt
@@ -33,11 +33,15 @@ class AppMonitoringService : Service() {
     private var breakTimer: CountDownTimer? = null
     private var lastEventTimestamp = 0L
     private var currentForegroundApp: String? = null
+    // Strict mode: apps granted a timed unlock, package -> expiry epoch millis
+    private val temporarilyUnlockedApps = java.util.concurrent.ConcurrentHashMap<String, Long>()
 
     companion object {
         const val NOTIFICATION_ID = 1
         const val CHANNEL_ID = "app_monitoring_channel"
         const val ACTION_START_BREAK = "com.cj.tapblok.ACTION_START_BREAK"
+        const val ACTION_UNLOCK_APP = "com.cj.tapblok.ACTION_UNLOCK_APP"
+        const val EXTRA_UNLOCK_PACKAGE = "com.cj.tapblok.extra.UNLOCK_PACKAGE"
         private const val INITIAL_EVENT_LOOKBACK_MS = 60 * 60 * 1000L
         @Volatile var isRunning = false
     }
@@ -54,6 +58,15 @@ class AppMonitoringService : Service() {
             startBreak()
             // The last onStartCommand return value governs restart-after-kill behaviour,
             // so a break must not downgrade the service to non-sticky
+            return START_STICKY
+        }
+
+        if (intent?.action == ACTION_UNLOCK_APP) {
+            intent.getStringExtra(EXTRA_UNLOCK_PACKAGE)?.let { unlockPackage ->
+                val minutes = prefs.getInt(AppSettings.KEY_UNLOCK_MINUTES, AppSettings.DEFAULT_UNLOCK_MINUTES)
+                temporarilyUnlockedApps[unlockPackage] = System.currentTimeMillis() + minutes * 60_000L
+                Log.d("AppMonitoringService", "Temporarily unlocked $unlockPackage for $minutes minutes.")
+            }
             return START_STICKY
         }
 
@@ -107,7 +120,9 @@ class AppMonitoringService : Service() {
                     val foregroundApp = getForegroundApp()
                     if (BuildConfig.DEBUG) Log.d("AppMonitoringService", "Current App: $foregroundApp")
 
-                    if (foregroundApp != null && foregroundApp in blockedApps && foregroundApp != packageName) {
+                    if (foregroundApp != null && foregroundApp in blockedApps &&
+                        foregroundApp != packageName && !isTemporarilyUnlocked(foregroundApp)
+                    ) {
                         val blockIntent = Intent(localContext, BlockingActivity::class.java).apply {
                             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                             putExtra("BLOCKED_APP_PACKAGE_NAME", foregroundApp)
@@ -126,6 +141,15 @@ class AppMonitoringService : Service() {
         }
 
         return START_STICKY
+    }
+
+    private fun isTemporarilyUnlocked(packageName: String): Boolean {
+        val expiry = temporarilyUnlockedApps[packageName] ?: return false
+        if (expiry <= System.currentTimeMillis()) {
+            temporarilyUnlockedApps.remove(packageName)
+            return false
+        }
+        return true
     }
 
     private fun startBreak() {

--- a/app/src/main/java/com/cj/tapblok/BlockingActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/BlockingActivity.kt
@@ -1,14 +1,17 @@
 package com.cj.tapblok
 
+import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -32,15 +35,46 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import coil.compose.rememberAsyncImagePainter
 import com.cj.tapblok.ui.theme.TapBlokTheme
+import com.journeyapps.barcodescanner.ScanContract
+import com.journeyapps.barcodescanner.ScanOptions
 
 class BlockingActivity : ComponentActivity() {
+
+    private var blockedPackage: String? = null
+    private var awaitingScanResult = false
+
+    private val qrScanLauncher = registerForActivityResult(ScanContract()) { result ->
+        awaitingScanResult = false
+        when (result.contents) {
+            null -> Unit // scan cancelled
+            QrCodeActivity.getOrCreateToken(this) -> unlockAndReturn()
+            QrCodeActivity.LEGACY_QR_CONTENT ->
+                Toast.makeText(
+                    this,
+                    "That QR code is from an older TapBlok version. Print a new one from \"Show QR Code\".",
+                    Toast.LENGTH_LONG
+                ).show()
+            else -> Toast.makeText(this, "Incorrect QR Code", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private val cameraPermissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (granted) launchScanner()
+        }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val packageName = intent.getStringExtra("BLOCKED_APP_PACKAGE_NAME") ?: "An app"
+        blockedPackage = intent.getStringExtra("BLOCKED_APP_PACKAGE_NAME")
+        val packageName = blockedPackage ?: "An app"
+        val prefs = AppSettings.prefs(this)
+        val strictMode = prefs.getBoolean(AppSettings.KEY_STRICT_MODE, false)
+        val unlockMinutes = prefs.getInt(AppSettings.KEY_UNLOCK_MINUTES, AppSettings.DEFAULT_UNLOCK_MINUTES)
 
         val goHome = {
             val intent = Intent(Intent.ACTION_MAIN).apply {
@@ -59,6 +93,8 @@ class BlockingActivity : ComponentActivity() {
             TapBlokTheme {
                 BlockingScreen(
                     packageName = packageName,
+                    strictMode = strictMode,
+                    unlockMinutes = unlockMinutes,
                     onGoHomeClick = goHome,
                     onTakeBreakClick = {
                         val breakIntent = Intent(this, AppMonitoringService::class.java).apply {
@@ -66,18 +102,72 @@ class BlockingActivity : ComponentActivity() {
                         }
                         startService(breakIntent)
                         finish()
+                    },
+                    onScanToUnlockClick = {
+                        if (ContextCompat.checkSelfPermission(this, Manifest.permission.CAMERA)
+                            == PackageManager.PERMISSION_GRANTED
+                        ) {
+                            launchScanner()
+                        } else {
+                            cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+                        }
                     }
                 )
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        AppForeground.onBlockingResumed(blockedPackage)
+    }
+
+    override fun onPause() {
+        super.onPause()
+        AppForeground.onBlockingPaused()
+    }
+
+    // The block screen is a gate, not a destination — close it whenever it leaves the
+    // screen so it doesn't linger in the back stack after an unlock or app switch.
+    // Skipped while the QR scanner is up, since that covers this activity too.
+    override fun onStop() {
+        super.onStop()
+        if (!isChangingConfigurations && !isFinishing && !awaitingScanResult) {
+            finish()
+        }
+    }
+
+    private fun launchScanner() {
+        awaitingScanResult = true
+        qrScanLauncher.launch(ScanOptions().setOrientationLocked(true))
+    }
+
+    private fun unlockAndReturn() {
+        val pkg = blockedPackage ?: return
+        val minutes = AppSettings.prefs(this)
+            .getInt(AppSettings.KEY_UNLOCK_MINUTES, AppSettings.DEFAULT_UNLOCK_MINUTES)
+        val unlockIntent = Intent(this, AppMonitoringService::class.java).apply {
+            action = AppMonitoringService.ACTION_UNLOCK_APP
+            putExtra(AppMonitoringService.EXTRA_UNLOCK_PACKAGE, pkg)
+        }
+        startService(unlockIntent)
+        Toast.makeText(this, "Unlocked for $minutes minute${if (minutes != 1) "s" else ""}.", Toast.LENGTH_SHORT).show()
+        packageManager.getLaunchIntentForPackage(pkg)?.let { launch ->
+            launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(launch)
+        }
+        finish()
     }
 }
 
 @Composable
 fun BlockingScreen(
     packageName: String,
+    strictMode: Boolean,
+    unlockMinutes: Int,
     onGoHomeClick: () -> Unit,
-    onTakeBreakClick: () -> Unit
+    onTakeBreakClick: () -> Unit,
+    onScanToUnlockClick: () -> Unit
 ) {
     val context = LocalContext.current
 
@@ -161,7 +251,12 @@ fun BlockingScreen(
             Spacer(modifier = Modifier.height(12.dp))
 
             Text(
-                text = "Tap your NFC tag or scan your QR code to unlock.",
+                text = if (strictMode) {
+                    "Tap your NFC tag or scan your QR code to unlock $appName for " +
+                            "$unlockMinutes minute${if (unlockMinutes != 1) "s" else ""}."
+                } else {
+                    "Tap your NFC tag or scan your QR code to unlock."
+                },
                 style = MaterialTheme.typography.bodyMedium,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 textAlign = TextAlign.Center
@@ -174,6 +269,16 @@ fun BlockingScreen(
                 modifier = Modifier.fillMaxWidth()
             ) {
                 Text("Go Home")
+            }
+
+            if (strictMode) {
+                Spacer(modifier = Modifier.height(12.dp))
+                OutlinedButton(
+                    onClick = onScanToUnlockClick,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text("Scan QR to Unlock")
+                }
             }
 
             if (breaksRemaining > 0) {

--- a/app/src/main/java/com/cj/tapblok/MainActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/MainActivity.kt
@@ -120,7 +120,7 @@ fun MainScreen() {
     val qrCodeScannerLauncher = rememberLauncherForActivityResult(
         contract = ScanContract()
     ) { result ->
-        if (result.contents == QrCodeActivity.QR_CODE_CONTENT) {
+        if (result.contents == QrCodeActivity.getOrCreateToken(context)) {
             if (isServiceRunning) {
                 context.stopService(Intent(context, AppMonitoringService::class.java))
                 Toast.makeText(context, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
@@ -130,6 +130,12 @@ fun MainScreen() {
                 Toast.makeText(context, "Monitoring started.", Toast.LENGTH_SHORT).show()
                 isServiceRunning = true
             }
+        } else if (result.contents == QrCodeActivity.LEGACY_QR_CONTENT) {
+            Toast.makeText(
+                context,
+                "That QR code is from an older TapBlok version. Print a new one from \"Show QR Code\".",
+                Toast.LENGTH_LONG
+            ).show()
         } else if (result.contents != null) {
             Toast.makeText(context, "Incorrect QR Code", Toast.LENGTH_SHORT).show()
         }
@@ -281,15 +287,19 @@ fun MainScreen() {
                             onClick = { context.startActivity(Intent(context, AppSelectionActivity::class.java)) }
                         )
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+                        // Both disabled during a session so a new unlock credential can't
+                        // be minted while blocking is active
                         ActionRow(
                             icon = Icons.Default.Nfc,
                             label = "Write NFC Tag",
+                            enabled = !isServiceRunning,
                             onClick = { context.startActivity(Intent(context, NfcWriteActivity::class.java)) }
                         )
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
                         ActionRow(
                             icon = Icons.Default.QrCode2,
                             label = "Show QR Code",
+                            enabled = !isServiceRunning,
                             onClick = { context.startActivity(Intent(context, QrCodeActivity::class.java)) }
                         )
                         HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))

--- a/app/src/main/java/com/cj/tapblok/NfcHandlerActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/NfcHandlerActivity.kt
@@ -1,5 +1,7 @@
 package com.cj.tapblok
 
+import android.annotation.SuppressLint
+import android.app.PendingIntent
 import android.content.Intent
 import android.nfc.NdefMessage
 import android.nfc.NfcAdapter
@@ -7,8 +9,14 @@ import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
 import androidx.activity.ComponentActivity
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
 
 class NfcHandlerActivity : ComponentActivity() {
+
+    companion object {
+        private const val STRICT_NOTIFICATION_ID = 2
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -35,21 +43,74 @@ class NfcHandlerActivity : ComponentActivity() {
                 }
 
                 Log.d("NfcHandlerActivity", "Valid TapBlok NFC tag detected.")
-
-                val serviceIntent = Intent(this, AppMonitoringService::class.java)
-
-                if (isServiceRunning(this, AppMonitoringService::class.java)) {
-                    // If the service is running, stop it.
-                    stopService(serviceIntent)
-                    Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
-                } else {
-                    // If the service is not running, start it.
-                    startMonitoringService(this)
-                    Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
-                }
+                handleValidTag()
             }
         }
         // Finish the activity immediately since it has no UI
         finish()
+    }
+
+    private fun handleValidTag() {
+        if (!isServiceRunning(this, AppMonitoringService::class.java)) {
+            startMonitoringService(this)
+            Toast.makeText(this, "Monitoring started.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val strictMode = AppSettings.prefs(this).getBoolean(AppSettings.KEY_STRICT_MODE, false)
+        val blockedPackage = AppForeground.blockedPackage
+        when {
+            !strictMode -> stopSession()
+            // Scanning on a block screen grants a timed unlock for that app only
+            AppForeground.isBlockingVisible() && blockedPackage != null ->
+                grantTemporaryUnlock(blockedPackage)
+            // Stopping the whole session requires TapBlok itself to be open
+            AppForeground.isMainVisible() -> stopSession()
+            else -> {
+                Toast.makeText(this, "Strict mode: open TapBlok, then scan again to stop.", Toast.LENGTH_LONG).show()
+                showStrictModeNotification()
+            }
+        }
+    }
+
+    private fun stopSession() {
+        stopService(Intent(this, AppMonitoringService::class.java))
+        Toast.makeText(this, "Monitoring stopped.", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun grantTemporaryUnlock(blockedPackage: String) {
+        val minutes = AppSettings.prefs(this)
+            .getInt(AppSettings.KEY_UNLOCK_MINUTES, AppSettings.DEFAULT_UNLOCK_MINUTES)
+        val unlockIntent = Intent(this, AppMonitoringService::class.java).apply {
+            action = AppMonitoringService.ACTION_UNLOCK_APP
+            putExtra(AppMonitoringService.EXTRA_UNLOCK_PACKAGE, blockedPackage)
+        }
+        startService(unlockIntent)
+        Toast.makeText(this, "Unlocked for $minutes minute${if (minutes != 1) "s" else ""}.", Toast.LENGTH_SHORT).show()
+        // Bring the unblocked app forward; the block screen closes itself once hidden
+        packageManager.getLaunchIntentForPackage(blockedPackage)?.let { launch ->
+            launch.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(launch)
+        }
+    }
+
+    // NotificationManagerCompat.notify silently drops the notification when
+    // POST_NOTIFICATIONS isn't granted; the toast above still explains what to do
+    @SuppressLint("MissingPermission")
+    private fun showStrictModeNotification() {
+        val contentIntent = PendingIntent.getActivity(
+            this, 0, Intent(this, MainActivity::class.java), PendingIntent.FLAG_IMMUTABLE
+        )
+        val notification = NotificationCompat.Builder(this, AppMonitoringService.CHANNEL_ID)
+            .setSmallIcon(R.mipmap.ic_launcher)
+            .setContentTitle("Strict mode is on")
+            .setContentText("Open TapBlok, then scan your tag again to stop the session.")
+            .setContentIntent(contentIntent)
+            .setAutoCancel(true)
+            .build()
+        val manager = NotificationManagerCompat.from(this)
+        if (manager.areNotificationsEnabled()) {
+            manager.notify(STRICT_NOTIFICATION_ID, notification)
+        }
     }
 }

--- a/app/src/main/java/com/cj/tapblok/QrCodeActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/QrCodeActivity.kt
@@ -1,5 +1,6 @@
 package com.cj.tapblok
 
+import android.content.Context
 import android.graphics.Bitmap
 import android.os.Bundle
 import android.util.Log
@@ -19,6 +20,7 @@ import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.core.content.edit
 import androidx.core.graphics.createBitmap
 import com.cj.tapblok.ui.theme.TapBlokTheme
 import com.google.zxing.BarcodeFormat
@@ -26,11 +28,26 @@ import com.google.zxing.EncodeHintType
 import com.google.zxing.qrcode.QRCodeWriter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.security.SecureRandom
 
 class QrCodeActivity : ComponentActivity() {
 
     companion object {
-        const val QR_CODE_CONTENT = "TAPBLOK_TOGGLE"
+        // The shared constant every install used before v1.5.0 — recognised only to
+        // tell users their printed code needs regenerating
+        const val LEGACY_QR_CONTENT = "TAPBLOK_TOGGLE"
+        private const val TOKEN_PREFIX = "TAPBLOK:"
+
+        // Generated once per install, so a QR printed from the repo or from someone
+        // else's phone can't control this device
+        fun getOrCreateToken(context: Context): String {
+            val prefs = AppSettings.prefs(context)
+            prefs.getString(AppSettings.KEY_QR_TOKEN, null)?.let { return it }
+            val bytes = ByteArray(16).also { SecureRandom().nextBytes(it) }
+            val token = TOKEN_PREFIX + bytes.joinToString("") { "%02x".format(it) }
+            prefs.edit { putString(AppSettings.KEY_QR_TOKEN, token) }
+            return token
+        }
     }
 
     @OptIn(ExperimentalMaterial3Api::class)
@@ -52,7 +69,7 @@ class QrCodeActivity : ComponentActivity() {
                 ) { padding ->
                     QrCodeScreen(
                         modifier = Modifier.padding(padding),
-                        content = QR_CODE_CONTENT
+                        content = getOrCreateToken(this)
                     )
                 }
             }
@@ -100,7 +117,8 @@ fun QrCodeScreen(modifier: Modifier = Modifier, content: String) {
         }
         Spacer(modifier = Modifier.height(24.dp))
         Text(
-            text = "Scan this code to start or stop a monitoring session.",
+            text = "Scan this code to start or stop a monitoring session. " +
+                    "It's unique to this install — print it and keep it somewhere that takes effort to reach.",
             style = MaterialTheme.typography.bodyLarge,
             textAlign = TextAlign.Center
         )

--- a/app/src/main/java/com/cj/tapblok/SettingsActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/SettingsActivity.kt
@@ -27,6 +27,9 @@ object AppSettings {
     const val KEY_OVERRIDE_ENABLED = "override_enabled"
     const val KEY_OVERRIDE_SECONDS = "override_seconds"
     const val KEY_BREAKS_ALLOWED = "breaks_allowed"
+    const val KEY_STRICT_MODE = "strict_mode_enabled"
+    const val KEY_UNLOCK_MINUTES = "strict_unlock_minutes"
+    const val KEY_QR_TOKEN = "qr_token"
     const val KEY_EXTERNAL_AUTOMATION = "external_automation_enabled"
     const val KEY_SCHEDULE_ENABLED = "schedule_enabled"
     const val KEY_SCHEDULE_START_MINUTES = "schedule_start_minutes"
@@ -37,6 +40,7 @@ object AppSettings {
 
     const val DEFAULT_OVERRIDE_SECONDS = 90
     const val DEFAULT_BREAKS_ALLOWED = 3
+    const val DEFAULT_UNLOCK_MINUTES = 5
     const val DEFAULT_START_MINUTES = 22 * 60
     const val DEFAULT_STOP_MINUTES = 7 * 60
     const val DEFAULT_DAYS_MASK = 0b1111111
@@ -81,6 +85,8 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
 
     var isServiceActive by remember { mutableStateOf(isServiceRunning(context, AppMonitoringService::class.java)) }
 
+    var strictMode by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_STRICT_MODE, false)) }
+    var unlockMinutes by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_UNLOCK_MINUTES, AppSettings.DEFAULT_UNLOCK_MINUTES)) }
     var overrideEnabled by remember { mutableStateOf(prefs.getBoolean(AppSettings.KEY_OVERRIDE_ENABLED, true)) }
     var overrideSeconds by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_OVERRIDE_SECONDS, AppSettings.DEFAULT_OVERRIDE_SECONDS)) }
     var breaksAllowed by remember { mutableStateOf(prefs.getInt(AppSettings.KEY_BREAKS_ALLOWED, AppSettings.DEFAULT_BREAKS_ALLOWED)) }
@@ -111,6 +117,45 @@ fun SettingsScreen(modifier: Modifier = Modifier) {
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.error,
                     modifier = Modifier.padding(16.dp)
+                )
+            }
+        }
+
+        SettingsSection(title = "Strict Mode") {
+            SettingsSwitchRow(
+                label = "Strict mode",
+                caption = "A session can only be stopped by scanning with TapBlok open. " +
+                        "Scanning on a block screen unlocks just that app, temporarily.",
+                checked = strictMode,
+                enabled = editable,
+                onCheckedChange = {
+                    strictMode = it
+                    prefs.edit { putBoolean(AppSettings.KEY_STRICT_MODE, it) }
+                }
+            )
+            if (strictMode) {
+                Text(
+                    text = "Temporary unlock duration",
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    listOf(1 to "1m", 5 to "5m", 10 to "10m", 30 to "30m").forEach { (minutes, label) ->
+                        FilterChip(
+                            selected = unlockMinutes == minutes,
+                            enabled = editable,
+                            onClick = {
+                                unlockMinutes = minutes
+                                prefs.edit { putInt(AppSettings.KEY_UNLOCK_MINUTES, minutes) }
+                            },
+                            label = { Text(label) }
+                        )
+                    }
+                }
+                Text(
+                    text = "For maximum friction, combine with zero breaks and a disabled emergency override.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
         }


### PR DESCRIPTION
Completes the remaining asks in #13. All strict behavior is opt-in; defaults are unchanged.

## Strict Mode (Settings → Strict Mode, off by default)

- A running session can only be stopped by scanning your tag/QR **while TapBlok is open**. Background scans leave the session running, show a toast, and post a notification explaining what to do.
- Scanning on a **block screen** grants a timed unlock for **that one app only** (1 / 5 / 10 / 30 min, configurable) instead of ending the session, then returns you to the app. The block screen also gets a "Scan QR to Unlock" button so QR-only users have the same flow.
- Deliberately orthogonal to breaks and the emergency override — each setting does one thing. The caption suggests combining strict + 0 breaks + disabled override for maximum friction.
- Foreground detection uses `ActivityLifecycleCallbacks` across all TapBlok screens (not just MainActivity), with a short grace window because the NFC intent pauses the underlying activity before the handler runs.

## Per-install QR token

The QR content was the hardcoded constant `TAPBLOK_TOGGLE` — identical on every install and visible in this repo, so anyone could print a working unlock code. Now each install generates a random 128-bit token on first use. Scanning a legacy code shows "print a new one" guidance rather than failing silently. **Existing NFC tags keep working** — only printed QR codes need regenerating.

## No credential minting mid-session

"Write NFC Tag" and "Show QR Code" are disabled while a session is active. Previously you could mint a fresh unlock credential during the very session it was supposed to gate.

## Also

- Block screen closes itself when hidden, so it no longer lingers in the back stack after unlocks/app switches.

Verified: `assembleDebug` and `assembleRelease` (lintVital + R8) build clean.