### PR TITLE
v1.5.1: Add camera apps to the safety exclusion list

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.cj.tapblok"
         minSdk = 24
         targetSdk = 36
-        versionCode = 7
-        versionName = "1.5.0"
+        versionCode = 8
+        versionName = "1.5.1"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
+++ b/app/src/main/java/com/cj/tapblok/AppSelectionActivity.kt
@@ -65,7 +65,21 @@ class AppSelectionViewModel(private val blockedAppDao: BlockedAppDao, private va
             "com.google.android.packageinstaller",
             "com.android.packageinstaller",
             "com.google.android.apps.messaging",
-            "com.samsung.android.messaging"
+            "com.samsung.android.messaging",
+            // Camera apps across major OEMs — the website promises the camera
+            // can never be blocked
+            "com.android.camera",
+            "com.android.camera2",
+            "com.google.android.GoogleCamera",
+            "com.sec.android.app.camera",
+            "com.oneplus.camera",
+            "com.oplus.camera",
+            "com.xiaomi.camera",
+            "com.huawei.camera",
+            "com.motorola.camera3",
+            "org.codeaurora.snapcam",
+            "com.sonymobile.photopro",
+            "com.asus.camera"
         )
     }
     private val _apps = MutableStateFlow<List<AppInfo>>(emptyList())

--- a/docs/index.html
+++ b/docs/index.html
@@ -62,7 +62,7 @@
       {
         "@type": "Question",
         "name": "Does TapBlok block system apps?",
-        "acceptedAnswer": { "@type": "Answer", "text": "No. A built-in safety list permanently excludes the dialer, SMS app, settings, system UI, and launcher so the phone always stays usable." }
+        "acceptedAnswer": { "@type": "Answer", "text": "No. A built-in safety list permanently excludes the dialer, SMS app, camera, settings, system UI, and launcher so the phone always stays usable." }
       },
       {
         "@type": "Question",
@@ -687,7 +687,7 @@
                 <span class="step-num">01</span>
                 <div class="step-body">
                   <h3>Pick your blocked apps</h3>
-                  <p>Choose any installed app. A safety list permanently excludes your dialer, messaging app, launcher, and settings so you can never brick your phone.</p>
+                  <p>Choose any installed app. A safety list permanently excludes your dialer, messaging app, camera, launcher, and settings so you can never brick your phone.</p>
                 </div>
               </li>
               <li>
@@ -919,7 +919,7 @@
               <li class="faq-item">
                 <button class="faq-q">Does TapBlok block system apps? <span class="faq-marker">+</span></button>
                 <div class="faq-a">
-                  <p>No. A built-in safety list permanently excludes your dialer, SMS app, settings, system UI, and launcher. You cannot accidentally make your phone unusable.</p>
+                  <p>No. A built-in safety list permanently excludes your dialer, SMS app, camera, settings, system UI, and launcher. You cannot accidentally make your phone unusable.</p>
                 </div>
               </li>
 


### PR DESCRIPTION
The site promised the camera can never be blocked, but the app's EXCLUDED_PACKAGES had no camera packages (caught during the site fact-check). This adds stock camera package names across major OEMs (AOSP, Pixel, Samsung, OnePlus/Oppo, Xiaomi, Huawei, Motorola, Snapdragon/codeaurora, Sony, Asus) so the claim is true in code, restores "camera" to the safety-list copy on the site (including the FAQPage JSON-LD), and bumps to v1.5.1 (versionCode 8).

Verified: assembleDebug and signed assembleRelease both build clean.