### PR TITLE
Add llms.txt, 404 page, security.txt, and SECURITY.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@
 
 ## ✨ Features
 
-- **🏷️ NFC Tag Support** — Write TapBlok's token to any NTAG213 tag (under $1 each). Tap to toggle a session.
+- **🏷️ NFC Tag Support** — Write TapBlok's token to any NDEF-compatible tag (NTAG213/215/216, under $1 each). Tap to toggle a session.
 - **📷 QR Code Support** — Generate a QR code in-app and print it. Hide it somewhere that requires real effort to reach. Every install gets its own unique code.
 - **🔐 Strict Mode** — Sessions can only be stopped by scanning with TapBlok open. Scanning on a block screen grants a short timed unlock for that one app instead of ending the session.
-- **🔒 Block Any App** — Choose any launchable app on your device. Critical system apps (dialer, settings, launcher) are permanently excluded so you can't lock yourself out.
+- **🔒 Block Any App** — Choose any launchable app on your device. Critical system apps (dialer, camera, settings, launcher) are permanently excluded so you can't lock yourself out.
 - **☕ Smart Breaks** — Take five-minute breaks without ending the session. Choose how many per session (0–5) in Settings.
 - **🔁 Boot Persistence** — If your device restarts mid-session, TapBlok picks right back up.
 - **🚨 Emergency Override** — Lost your tag? A hold-to-stop last resort. Set the hold anywhere from 30 seconds to 15 minutes, or disable it entirely for strict sessions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Supported Versions
+
+Only the [latest release](https://github.com/cajdata/TapBlok/releases/latest) is supported. TapBlok runs entirely on-device with no server component, so updating to the newest APK is always the fix path.
+
+## Reporting a Vulnerability
+
+If you find a security issue — for example a way to bypass blocking that crosses the app's stated guarantees, or a problem in the NFC/QR token handling — please email **tapblokdev@gmail.com** instead of opening a public issue. Include steps to reproduce and your Android version/device.
+
+You can expect an initial reply within a week. Once a fix ships, credit is yours if you want it.
+
+Deliberate-workaround reports (e.g., "I can uninstall the app to stop blocking") aren't vulnerabilities — TapBlok adds friction against impulse, not against a determined device owner.

--- a/docs/.well-known/security.txt
+++ b/docs/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:tapblokdev@gmail.com
+Expires: 2027-07-06T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://tapblok.com/.well-known/security.txt
+Policy: https://github.com/cajdata/TapBlok/blob/main/SECURITY.md

--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Page not found | TapBlok</title>
+  <meta name="robots" content="noindex" />
+  <link rel="icon" type="image/png" href="/icon.png" />
+  <style>
+    body {
+      background: #faf9f5;
+      color: #2e2e2b;
+      font-family: Georgia, 'Times New Roman', Times, serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      margin: 0;
+      text-align: center;
+    }
+    h1 { font-size: 2rem; margin-bottom: 0.5rem; }
+    p { color: #6b6b66; margin-bottom: 1.5rem; }
+    a {
+      display: inline-block;
+      background: #1a1a18;
+      color: #faf9f5;
+      text-decoration: none;
+      padding: 0.7rem 1.5rem;
+      font-family: system-ui, sans-serif;
+      font-size: 0.9rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>Page not found</h1>
+    <p>This page doesn't exist — everything lives on the home page.</p>
+    <a href="/">Back to TapBlok</a>
+  </main>
+</body>
+</html>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,26 @@
+# TapBlok
+
+> TapBlok is a free, open-source Android app blocker unlocked by a physical NFC tag or QR code. You pick the apps to block, start a session, and put the tag out of reach — ending the session requires physically retrieving it. No subscription, no account, no cloud, no ads, no telemetry. Apache 2.0 licensed.
+
+Key facts:
+
+- Platform: Android 7.0 (API 24) and up. Distributed as a signed APK on GitHub Releases (not on Google Play).
+- Price: free forever. The common paid alternatives are Brick ($59 device), Opal ($99.99/yr), Freedom ($39.99/yr), and One Sec ($19/yr).
+- Unlock methods: any NDEF-compatible NFC tag (NTAG213/215/216), or a per-install QR code generated in the app.
+- Strict Mode: sessions can only be stopped by scanning with TapBlok open in the foreground; scanning on a block screen unlocks just that one app for a limited time (1–30 minutes).
+- Scheduled Blocking: sessions start and stop automatically at chosen times and days, including overnight windows.
+- Automation: opt-in broadcast actions (com.cj.tapblok.SCHEDULE_START / SCHEDULE_STOP) let Tasker, MacroDroid, or Samsung Routines trigger sessions.
+- Configurable friction: 0–5 five-minute breaks per session; emergency override hold adjustable from 30 seconds to 15 minutes or disabled entirely.
+- Safety list: the dialer, SMS app, camera, settings, system UI, and launcher can never be blocked.
+- Privacy: everything runs locally on-device in a Room database; no account, no analytics, internet not required.
+
+## Documentation
+
+- [README](https://github.com/cajdata/TapBlok/blob/main/README.md): setup, permissions, NFC tag writing, strict mode, scheduling, and Tasker automation examples
+- [Releases](https://github.com/cajdata/TapBlok/releases): signed APK downloads and changelogs
+- [Source code](https://github.com/cajdata/TapBlok): full Kotlin/Jetpack Compose source, Apache 2.0
+
+## Optional
+
+- [Issue tracker](https://github.com/cajdata/TapBlok/issues): bug reports and feature requests
+- [Website](https://tapblok.com/): feature overview, comparison table, and OEM-specific battery-settings FAQ


### PR DESCRIPTION
Discovery/hygiene files the site and repo were missing:

- **docs/llms.txt** — LLM-friendly summary per the llmstxt.org convention. AI search assistants fielding "best free app blocker android" questions get accurate facts (pricing vs competitors, strict mode, scheduling, privacy) with canonical links.
- **docs/404.html** — minimal branded not-found page matching the site style; noindexed.
- **docs/.well-known/security.txt** (RFC 9116) + **SECURITY.md** — routes vulnerability reports to tapblokdev@gmail.com instead of public issues; GitHub surfaces SECURITY.md in the repo Security tab.
- **docs/.nojekyll** — required so Pages serves the dotted `.well-known/` path; also skips the pointless Jekyll build (site is plain HTML).
- **README** — NTAG213 → NDEF-compatible (matches site copy), camera added to the safety-list line now that v1.5.1 ships it.

No changes to index.html. Pages redeploys on merge.