### PR TITLE
Add personal house-for-sale note to footer

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1041,6 +1041,7 @@
     </nav>
     <p class="legal">Made in Denver, CO &nbsp;&middot;&nbsp; TapBlok is free and open source under the Apache 2.0 license.</p>
     <p class="legal">As an Amazon Associate I earn from qualifying purchases.</p>
+    <p class="legal">On a personal note: my house is for sale. Take a look at <a href="https://8722independenceway.com" target="_blank" rel="noopener" style="color:var(--amber-dk);">8722 Independence Way in Arvada, CO</a>.</p>
   </footer>
 
   <script>


### PR DESCRIPTION
Adds one footer line after the Amazon disclosure:

> On a personal note: my house is for sale. Take a look at [8722 Independence Way in Arvada, CO](https://8722independenceway.com).

- Followed link (no nofollow) since the backlink is the point; `target="_blank" rel="noopener"` matches the other external links.
- Anchor text is the full address + city, which is what people search for a listing.
- Target verified live before linking (200, title: "8722 Independence Way, Arvada, CO 80005 | 4 Bed Patio Home for Sale | $610,000").